### PR TITLE
Removed bImmunitySkills from Immunity_Wards check.

### DIFF
--- a/addons/sourcemod/scripting/W3SIncs/War3Source_Buffs.inc
+++ b/addons/sourcemod/scripting/W3SIncs/War3Source_Buffs.inc
@@ -100,7 +100,7 @@ stock bool:W3HasImmunity(client,War3Immunity:immunityindex)
         return W3GetBuffHasTrue(client,bImmunityUltimates);
     }
     if(immunityindex==Immunity_Wards) {
-        return W3GetBuffHasTrue(client,bImmunityWards)||W3GetBuffHasTrue(client,bImmunitySkills);
+        return W3GetBuffHasTrue(client,bImmunityWards);
     }
 
     return false;


### PR DESCRIPTION
Why does bImmunityWards (Antiwards) allow both bImmunitySkills and bImmunitywards check?
This would mean I could buy antiwards and have the benefits of shield included with my antiwards.
It makes no sense at all to have bImmunitySkills included with Immunity to wards.
