### PR TITLE
fixed SQLFastQuery ALTER TABLE error

### DIFF
--- a/addons/sourcemod/scripting/War3Source_Engine_DatabaseSaveXP.sp
+++ b/addons/sourcemod/scripting/War3Source_Engine_DatabaseSaveXP.sp
@@ -113,12 +113,6 @@ Initialize_SQLTable()
 				}
 				else
 				{
-						// Old Databases may not have diamonds since the removal of it in 2.0
-						// Adding this for a just in case.
-						if(!SQL_FieldNameToNum(query, "diamonds", dummy))
-						{
-							AddColumn(hDB,"diamonds","int","war3source");
-						}
 
 						//table exists by now, add skill columns if not exists
 						new String:columnname[16];


### PR DESCRIPTION
the error:
SQLFastQuery ALTER TABLE war3source ADD COLUMN diamonds int DEFAULT '0' failed, Error: Duplicate column name 'diamonds'

fixed.
