### PR TITLE
Fixed Issue #118 - Fluttershy bug (Stare Master)

### DIFF
--- a/addons/sourcemod/scripting/War3Source.sp
+++ b/addons/sourcemod/scripting/War3Source.sp
@@ -1,4 +1,6 @@
- 
+// Release date is based on Month.Day.Year of when it was last changed
+#define RELEASE_DATE "9/1/2013"
+
 /*  This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -115,7 +117,6 @@ And that's the art of the test!
 //#include <profiler>
 #include "W3SIncs/War3Source_Interface"
 
-
 //THESE are updated less frequently
 //JENKINS overwrites these
 #define BRANCH "undef"
@@ -175,6 +176,7 @@ public APLRes:AskPluginLoad2Custom(Handle:myself,bool:late,String:error[],err_ma
     CreateConVar("a_war3_version", version, "War3Source version.", FCVAR_PLUGIN|FCVAR_SPONLY|FCVAR_REPLICATED|FCVAR_NOTIFY|FCVAR_DONTRECORD);
     CreateConVar("war3_branch", BRANCH, "War3Source branch.", FCVAR_PLUGIN|FCVAR_SPONLY|FCVAR_REPLICATED|FCVAR_NOTIFY|FCVAR_DONTRECORD);
     CreateConVar("war3_buildnumber", BUILD_NUMBER, "War3Source build number.", FCVAR_PLUGIN|FCVAR_SPONLY|FCVAR_REPLICATED|FCVAR_NOTIFY|FCVAR_DONTRECORD);
+    CreateConVar("war3_release", RELEASE_DATE, "War3Source version release date.", FCVAR_PLUGIN|FCVAR_SPONLY|FCVAR_REPLICATED|FCVAR_NOTIFY|FCVAR_DONTRECORD);
     
     CreateNative("W3GetW3Version", NW3GetW3Version);
     CreateNative("W3GetW3Revision", NW3GetW3Revision);

--- a/addons/sourcemod/scripting/War3Source_021_Fluttershy.sp
+++ b/addons/sourcemod/scripting/War3Source_021_Fluttershy.sp
@@ -88,7 +88,6 @@ public OnW3TakeDmgBulletPre(victim,attacker,Float:damage){
     }
 } 
 
-new Handle:StareEndTimer[MAXPLAYERSCUSTOM]; //invalid handle by default
 new StareVictim[MAXPLAYERSCUSTOM];
 
 public OnAbilityCommand(client,ability,bool:pressed)
@@ -111,7 +110,7 @@ public OnAbilityCommand(client,ability,bool:pressed)
                     War3_SetBuff(target,bDisarm,thisRaceID,true);
                     PrintHintText(client,"%t","STOP AND STARE",client);
                     PrintHintText(target,"%t","You are being stared at.Don't look at her in the eye!!!",client);
-                    StareEndTimer[client]=CreateTimer(StareDuration[skilllvl],EndStare,client);
+                    CreateTimer(StareDuration[skilllvl],EndStare,client);
                     StareVictim[client]=target;
                     War3_CooldownMGR(client,15.0,thisRaceID,SKILL_STARE);
                 }
@@ -128,12 +127,16 @@ public Action:EndStare(Handle:t,any:client){
     War3_SetBuff(StareVictim[client],bBashed,thisRaceID,false);
     War3_SetBuff(StareVictim[client],bDisarm,thisRaceID,false);
     StareVictim[client]=0;
-    StareEndTimer[client]=INVALID_HANDLE;
 }
+
 public OnWar3EventDeath(client){ //end stare if fluttershy dies
-    if(StareEndTimer[client]){
-        TriggerTimer(StareEndTimer[client]);
-        StareEndTimer[client]=INVALID_HANDLE;
+    if(ValidPlayer(client))
+    {
+        War3_SetBuff(client,bBashed,thisRaceID,false);
+        War3_SetBuff(client,bDisarm,thisRaceID,false);
+        War3_SetBuff(StareVictim[client],bBashed,thisRaceID,false);
+        War3_SetBuff(StareVictim[client],bDisarm,thisRaceID,false);
+        StareVictim[client]=0;
     }
 }
 


### PR DESCRIPTION
Fixed Issue #118 - Fluttershy bug (Stare Master)
## 9/1/2013
- Added war3_release convar what will be in the server variables to show the release date of the version your running.   This date is manually updated by anyone whom updates a pull request to the GitHub.   It is not meant to be a automatic update system.    It is meant to correspond to these releases posted here.
- FlutterShy Bug Fixed - The code with FlutterShy "looks good", but under real conditions of a server we have found that stare master somehow does not trigger the timer correctly on death and causes players to get "stuck" forever until they reconnect to the server.   I have corrected the issue by hard programming into the OnWar3EventDeath event between lines 132 - 141 in War3Source_021_Fluttershy.sp
