### PR TITLE
Updated Aura System

### DIFF
--- a/addons/sourcemod/scripting/W3SIncs/War3Source_Aura.inc
+++ b/addons/sourcemod/scripting/W3SIncs/War3Source_Aura.inc
@@ -3,6 +3,7 @@
 //by default tracks teammates only
 //Track other team will track other team only, if you want to track both teams, use two different auras
 //aura not does take account of line of sight
+// Kept backwards compatible for easy buff
 native W3RegisterAura(String:auraShortName[],Float:distance,bool:trackotherteam=false);
 
 //set and unset a player if he has or no longer has the origin of the aura
@@ -10,6 +11,30 @@ native W3RegisterAura(String:auraShortName[],Float:distance,bool:trackotherteam=
 //level (optional) is a integer for a priority system, such as teammate has level 1 heal wave and another teammate has level 4 heal wave
 //the player recieves the level 4 heal wave and does not stack with level 1 heal wave
 native W3SetAuraFromPlayer(tAuraID,client,bool:auraOriginatesFromPlayer=true,level=1);
+
+
+
+// Advanced Aura System can handle multiple distances
+// If you want to be able to setup your race with a aura system that uses multiple
+// distances based on skill level, then use the system below
+
+// Use below to register, set, and remove your auras for the new system.
+// you can "reregister the aura to switch the trackotherteam" using this system
+native W3RegisterChangingDistanceAura(String:auraShortName[],bool:trackotherteam=false);
+
+//removed if player disconnects
+//level (optional) is a integer for a priority system, such as teammate has level 1 heal wave and another teammate has level 4 heal wave
+//the player recieves the level 4 heal wave and does not stack with level 1 heal wave
+//the distance for the aura of the client
+native W3SetPlayerAura(tAuraID,client,Float:distance,level=0);
+
+// A Simple Way to remove an aura from the player you had used SetAuraFromPlayer
+native W3RemovePlayerAura(tAuraID,client);
+
+
+
+
+// THE SYSTEM BELOW IS COMPATIBLE WITH BOTH SYSTEMS:
 
 ///is this player under the influence of this aura?
 ///it means player is within distance of an aura origin (ie a player)
@@ -19,4 +44,3 @@ native bool:W3HasAura(tAuraID,client,&level);
 //forward when a player's aura state changes, ie leaves the area, or dies
 //however player may be dead while the aura lingers, always check for alive in your function
 forward OnW3PlayerAuraStateChanged(client,tAuraID,bool:inAura,level);
-

--- a/addons/sourcemod/scripting/War3Source.sp
+++ b/addons/sourcemod/scripting/War3Source.sp
@@ -1,5 +1,5 @@
 // Release date is based on Month.Day.Year of when it was last changed
-#define RELEASE_DATE "9/1/2013"
+#define RELEASE_DATE "9/3/2013"
 
 /*  This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/addons/sourcemod/scripting/War3Source_006_ShadowHunter.sp
+++ b/addons/sourcemod/scripting/War3Source_006_ShadowHunter.sp
@@ -21,7 +21,7 @@ new SKILL_HEALINGWAVE, SKILL_HEX, SKILL_WARD, ULT_VOODOO;
 
 //skill 1
 new Float:HealingWaveAmountArr[]={0.0,1.0,2.0,3.0,4.0};
-new Float:HealingWaveDistance=500.0;
+new Float:HealingWaveDistance[]={0.0,450.0,500.0,550.0,600.0};
 new ParticleEffect[MAXPLAYERSCUSTOM][MAXPLAYERSCUSTOM]; // ParticleEffect[Source][Destination]
 
 //skill 2
@@ -75,7 +75,7 @@ public OnWar3LoadRaceOrItemOrdered(num)
         SKILL_WARD=War3_AddRaceSkillT(thisRaceID,"SerpentWards",false,4);
         ULT_VOODOO=War3_AddRaceSkillT(thisRaceID,"BigBadVoodoo",true,4); 
         War3_CreateRaceEnd(thisRaceID);
-        AuraID=W3RegisterAura("hunter_healwave",HealingWaveDistance);
+        AuraID=W3RegisterChangingDistanceAura("hunter_healwave");
         
     }
 
@@ -101,13 +101,16 @@ public OnRaceChanged(client,oldrace,newrace)
     if(newrace==thisRaceID)
     {
         new level=War3_GetSkillLevel(client,thisRaceID,SKILL_HEALINGWAVE);
-        W3SetAuraFromPlayer(AuraID,client,level>0?true:false,level);
+        if(level>0)
+        {
+            W3SetPlayerAura(AuraID,client,HealingWaveDistance[level],level);
+        }
         
     }
     else{
         //PrintToServer("deactivate aura");
         War3_SetBuff(client,bImmunitySkills,thisRaceID,false);
-        W3SetAuraFromPlayer(AuraID,client,false);
+        W3RemovePlayerAura(AuraID,client);
     }
 }
 
@@ -118,7 +121,11 @@ public OnSkillLevelChanged(client,race,skill,newskilllevel)
     {
         if(skill==SKILL_HEALINGWAVE) //1
         {
-            W3SetAuraFromPlayer(AuraID,client,newskilllevel>0?true:false,newskilllevel);
+            W3RemovePlayerAura(AuraID,client);
+            if(newskilllevel>0)
+            {
+                W3SetPlayerAura(AuraID,client,HealingWaveDistance[newskilllevel],newskilllevel);
+            }
         }
     }
 }
@@ -296,6 +303,7 @@ public OnW3PlayerAuraStateChanged(client,aura,bool:inAura,level)
 {
     if(aura==AuraID)
     {
+        //DP(inAura?"[SH] in aura":"[SH] not in aura");
         War3_SetBuff(client,fHPRegen,thisRaceID,inAura?HealingWaveAmountArr[level]:0.0);
     }
 }

--- a/addons/sourcemod/scripting/War3Source_018_Scout.sp
+++ b/addons/sourcemod/scripting/War3Source_018_Scout.sp
@@ -36,7 +36,7 @@ new standStillCount[MAXPLAYERSCUSTOM];
 // Effects
 //new BeamSprite,HaloSprite;
 
-new auras[5];
+new thisAuraID;
 
 public OnPluginStart()
 {
@@ -67,11 +67,8 @@ public OnWar3LoadRaceOrItemOrdered(num)
         ULT_MARKSMAN=War3_AddRaceSkillT(thisRaceID,"Marksman",true,4,"1.2-1.6"); 
     
         War3_CreateRaceEnd(thisRaceID);
-        
-        auras[1] =W3RegisterAura("scout_reveal1",EyeRadius[1],true);
-        auras[2] =W3RegisterAura("scout_reveal2",EyeRadius[2],true);
-        auras[3] =W3RegisterAura("scout_reveal3",EyeRadius[3],true);    
-        auras[4] =W3RegisterAura("scout_reveal4",EyeRadius[4],true);
+         //EyeRadius[1]
+        thisAuraID =W3RegisterChangingDistanceAura("scout_reveal",true);
 
         //ServerCommand("war3 scout_flags hidden");
         //ServerExecute();
@@ -84,11 +81,11 @@ public OnRaceChanged(client,oldrace,newrace)
     {
         new level=War3_GetSkillLevel(client,thisRaceID,SKILL_TRUESIGHT);
         if(level>0){
-            W3SetAuraFromPlayer(auras[level],client,true,level);
+            W3SetPlayerAura(thisAuraID,client,EyeRadius[level],level);
         }
     }
     else if(oldrace==thisRaceID){
-        ClearAura(client);
+        W3RemovePlayerAura(thisAuraID,client);
     }
 }
 
@@ -99,19 +96,14 @@ public OnSkillLevelChanged(client,race,skill,newskilllevel)
     {
         if(skill==SKILL_TRUESIGHT) //1
         {
-            ClearAura(client);
+            W3RemovePlayerAura(thisAuraID,client);
             if(newskilllevel>0){
-                W3SetAuraFromPlayer(auras[newskilllevel],client,true,newskilllevel);
+                W3SetPlayerAura(thisAuraID,client,EyeRadius[newskilllevel],newskilllevel);
             }
         }
     }
 }
-ClearAura(client){
-    W3SetAuraFromPlayer(auras[1],client,false);
-    W3SetAuraFromPlayer(auras[2],client,false);
-    W3SetAuraFromPlayer(auras[3],client,false);
-    W3SetAuraFromPlayer(auras[4],client,false);
-}
+
 public OnWar3EventSpawn(client){
     if(bDisarmed[client]){
         EndInvis2(INVALID_HANDLE,client);
@@ -259,12 +251,9 @@ public OnUltimateCommand(client,race,bool:pressed)
     }
 }
 public OnW3PlayerAuraStateChanged(client,tAuraID,bool:inAura,level){
-    if(tAuraID==auras[1]||
-    tAuraID==auras[2]||
-    tAuraID==auras[3]||
-    tAuraID==auras[4]){
+    if(tAuraID==thisAuraID){
+        //DP(inAura?"In Aura":"Not in Aura");
         War3_SetBuff(client,bInvisibilityDenyAll,thisRaceID,inAura);
-        
     }
     
 }

--- a/addons/sourcemod/scripting/War3Source_021_Fluttershy.sp
+++ b/addons/sourcemod/scripting/War3Source_021_Fluttershy.sp
@@ -20,7 +20,7 @@ public LoadCheck(){
 
 new SKILL_STARE,SKILL_TOLERATE,SKILL_KINDNESS,ULTIMATE_YOUBEGENTLE;
 new AuraID;
-new Float:HealingWaveDistance=133.0;
+new Float:HealingWaveDistance[5]={0.0,100.0,125.0,150.0,175.0};
 new Float:starerange=300.0;
 new Float:StareDuration[5]={0.0,1.5,2.0,2.5,3.0};
 new Float:ArmorPhysical[5]={0.0,0.5,1.0,1.5,2.0};
@@ -42,7 +42,7 @@ public OnWar3LoadRaceOrItemOrdered(num)
         War3_CreateRaceEnd(thisRaceID); ///DO NOT FORGET THE END!!!
         
         
-        AuraID=W3RegisterAura("fluttershy_healwave",HealingWaveDistance);
+        AuraID=W3RegisterChangingDistanceAura("fluttershy_healwave");
     }
 }
 
@@ -153,7 +153,11 @@ public OnSkillLevelChanged(client,race,skill,newskilllevel)
     }
     if(race==thisRaceID &&skill==SKILL_KINDNESS) //1
     {
-            W3SetAuraFromPlayer(AuraID,client,newskilllevel>0?true:false,newskilllevel);
+        W3RemovePlayerAura(AuraID,client);
+        if(newskilllevel>0)
+        {
+            W3SetPlayerAura(AuraID,client,HealingWaveDistance[newskilllevel],newskilllevel);
+        }
     }
 }
 
@@ -182,7 +186,7 @@ RecalculateHealing(){
     {
         if(ValidPlayer(client,true)&&W3HasAura(AuraID,client,level)){
             for(new i=0;i<playercount;i++){
-                if(GetPlayerDistance(playerlist[i],client)<HealingWaveDistance){
+                if(GetPlayerDistance(playerlist[i],client)<HealingWaveDistance[level]){
                     auraactivated[playercount]++;
                     auraactivated[i]++;
                 }

--- a/addons/sourcemod/scripting/War3Source_Engine_Aura.sp
+++ b/addons/sourcemod/scripting/War3Source_Engine_Aura.sp
@@ -11,13 +11,14 @@ public Plugin:myinfo =
 };
 
 new bool:AuraOrigin[MAXPLAYERSCUSTOM][MAXAURAS];
-new bool:AuraOriginLevel[MAXPLAYERSCUSTOM][MAXAURAS];
+new AuraOriginLevel[MAXPLAYERSCUSTOM][MAXAURAS];
+
+new Float:AuraDistance[MAXPLAYERSCUSTOM][MAXAURAS];
 
 new HasAura[MAXPLAYERSCUSTOM][MAXAURAS]; //int, we just count up
 new HasAuraLevel[MAXPLAYERSCUSTOM][MAXAURAS];
 
 new String:AuraShort[MAXAURAS][32];
-new Float:AuraDistance[MAXAURAS];
 new bool:AuraTrackOtherTeam[MAXAURAS];
 new AuraCount=0;
 
@@ -32,9 +33,16 @@ public OnPluginStart()
 public bool:InitNativesForwards()
 {
     
-    
+    //Backwards compatible old format / easy buff compatible
     CreateNative("W3RegisterAura",NW3RegisterAura);//for races
     CreateNative("W3SetAuraFromPlayer",NW3SetAuraFromPlayer);
+
+    // New format allows greater flexiblity with distances
+    CreateNative("W3RegisterChangingDistanceAura",NW3RegisterChangingDistanceAura);//for races
+    CreateNative("W3SetPlayerAura",NW3SetPlayerAura);
+
+    // Both systems use this:
+    CreateNative("W3RemovePlayerAura",NW3RemovePlayerAura);
     CreateNative("W3HasAura",NW3HasAura);
     
     g_Forward=CreateGlobalForward("OnW3PlayerAuraStateChanged",ET_Ignore,Param_Cell,Param_Cell,Param_Cell,Param_Cell);
@@ -58,10 +66,14 @@ public NW3RegisterAura(Handle:plugin,numParams)
         AuraCount++;
         strcopy(AuraShort[AuraCount], 32, taurashort);
         
-        AuraDistance[AuraCount] = Float:GetNativeCell(2);
+        for(new client=1;client<=MaxClients;client++)
+        {
+            AuraDistance[client][AuraCount] = Float:GetNativeCell(2);
+        }
+        
         AuraTrackOtherTeam[AuraCount] = bool:GetNativeCell(3);
         
-        War3_LogInfo("Registered aura \"%s\" with a distance of \"%f\". TrackOtherTeam: %i", AuraShort[AuraCount], AuraDistance[AuraCount], AuraTrackOtherTeam[AuraCount]);
+        War3_LogInfo("Registered aura \"%s\" with a distance of \"%f\". TrackOtherTeam: %i", AuraShort[AuraCount], AuraDistance[1][AuraCount], AuraTrackOtherTeam[AuraCount]);
         return AuraCount;
     }
     else
@@ -77,6 +89,57 @@ public NW3SetAuraFromPlayer(Handle:plugin,numParams)
     new client=GetNativeCell(2);
     AuraOrigin[client][aura]=bool:GetNativeCell(3);
     AuraOriginLevel[client][aura]=GetNativeCell(4);
+}
+
+
+
+public NW3RegisterChangingDistanceAura(Handle:plugin,numParams)
+{
+    new String:taurashort[32];
+    GetNativeString(1,taurashort,32);
+    
+    for(new aura=1; aura <= AuraCount; aura++)
+    {
+        if(StrEqual(taurashort, AuraShort[aura], false))
+        {
+            // Change values of aura, since its already registered
+            AuraTrackOtherTeam[aura] = bool:GetNativeCell(2);
+            War3_LogInfo("Changed - Registered aura \"%s\" TrackOtherTeam: %i", AuraShort[aura], AuraTrackOtherTeam[aura]);
+            return aura; //already registered
+        }
+    }
+    if(AuraCount + 1 < MAXAURAS)
+    {
+        AuraCount++;
+        strcopy(AuraShort[AuraCount], 32, taurashort);
+        
+        AuraTrackOtherTeam[AuraCount] = bool:GetNativeCell(2);
+        
+        War3_LogInfo("Registered aura \"%s\" TrackOtherTeam: %i", AuraShort[AuraCount], AuraTrackOtherTeam[AuraCount]);
+        return AuraCount;
+    }
+    else
+    {
+        ThrowError("CANNOT REGISTER ANY MORE AURAS");
+    }
+    
+    return -1;
+}
+public NW3SetPlayerAura(Handle:plugin,numParams)
+{
+    new aura=GetNativeCell(1);
+    new client=GetNativeCell(2);
+    AuraDistance[client][aura]=Float:GetNativeCell(3);
+    AuraOrigin[client][aura]=true;
+    AuraOriginLevel[client][aura]=GetNativeCell(4);
+}
+public NW3RemovePlayerAura(Handle:plugin,numParams)
+{
+    new aura=GetNativeCell(1);
+    new client=GetNativeCell(2);
+    AuraDistance[client][aura]=0.0;
+    AuraOrigin[client][aura]=false;
+    AuraOriginLevel[client][aura]=0;
 }
 public NW3HasAura(Handle:plugin,numParams)
 {
@@ -96,6 +159,7 @@ InternalClearPlayerVars(client){
     for(new aura=1;aura<=AuraCount;aura++)
     {
         AuraOrigin[client][aura]=false;
+        AuraDistance[client][aura]=0.0;
     }
 }
 //re calculate auras when one of these things happen, however a 0.1 delay minimum (like 32 players spawn at round start, we dont calculate 32 times)
@@ -117,8 +181,8 @@ public Action:CalcAura(Handle:t)
         for(new aura=1;aura<=AuraCount;aura++){
             OldHasAura[client][aura]=HasAura[client][aura];
             OldHasAuraLevel[client][aura]=HasAuraLevel[client][aura];
-            HasAura[client][aura]=0; //clear
-            HasAuraLevel[client][aura]=0; 
+            HasAura[client][aura]=0; //clear bool aura
+            HasAuraLevel[client][aura]=-1; // clear levels 
         }
     }
     
@@ -141,36 +205,30 @@ public Action:CalcAura(Handle:t)
                     GetClientAbsOrigin(client,vec1);
                     GetClientAbsOrigin(target,vec2);
                     new Float:dis=GetVectorDistance(vec1,vec2);
-                    //Distances[client][target]=dis;
-                    //Distances[target][client]=dis;
                     //DP("aura %d  %f",client,dis);
                     for(new aura=1;aura<=AuraCount;aura++){
-                        if(dis<AuraDistance[aura]){
+                        //boolean magic!!!!!!!! De Morgan wuz here   (And El Diablo improved it! 9/3/2013)
+
+                        //client originating an aura
+                        if(AuraOrigin[client][aura] && dis<AuraDistance[client][aura]){ 
+                            //DP("aura origin %d",client);
+                            if( (!AuraTrackOtherTeam[aura])==(teamclient==teamtarget)) 
+                            // || (AuraTrackOtherTeam[aura]&&teamclient!=teamtarget)
                             
-                            //boolean magic!!!!!!!! De Morgan wuz here
-                            //client originating an aura
-                            if(AuraOrigin[client][aura] ){ 
-                                //DP("aura origin %d",client);
-                                if( (!AuraTrackOtherTeam[aura])==(teamclient==teamtarget)) 
-                                // || (AuraTrackOtherTeam[aura]&&teamclient!=teamtarget)
-                                
-                                {
-                                    //DP("aura target on %d",target);
-                                    HasAura[target][aura]++;
-                                    HasAuraLevel[target][aura]=IntMax(HasAuraLevel[target][aura],AuraOriginLevel[client][aura]); //what level is larger, old level or new level brought by the new origin player
-                                }
+                            {
+                                //DP("aura target on %d",target);
+                                HasAura[target][aura]++;
+                                HasAuraLevel[target][aura]=IntMax(HasAuraLevel[target][aura],AuraOriginLevel[client][aura]); //what level is larger, old level or new level brought by the new origin player
                             }
+                        }
+                        //target originating an aura
+                        if(AuraOrigin[target][aura] &&target!=client && dis<AuraDistance[target][aura]){  //skip if client is target, which we already did up top
+                            if( (!AuraTrackOtherTeam[aura])==(teamclient==teamtarget)   ) 
+                                //|| (AuraTrackOtherTeam[aura]&&teamclient!=teamtarget)
                             
-                            
-                            //target originating an aura
-                            if(AuraOrigin[target][aura] &&target!=client ){  //skip if client is target, which we already did up top
-                                if( (!AuraTrackOtherTeam[aura])==(teamclient==teamtarget)   ) 
-                                 //|| (AuraTrackOtherTeam[aura]&&teamclient!=teamtarget)
-                                
-                                {
-                                    HasAura[client][aura]++;
-                                    HasAuraLevel[client][aura]=IntMax(HasAuraLevel[client][aura],AuraOriginLevel[target][aura]);
-                                }
+                            {
+                                HasAura[client][aura]++;
+                                HasAuraLevel[client][aura]=IntMax(HasAuraLevel[client][aura],AuraOriginLevel[target][aura]);
                             }
                         }
                     }


### PR DESCRIPTION
For what ever reason i would never understand, is since the early version of the aura system it has only allowed level 1 auras due to this:

new bool:AuraOriginLevel[MAXPLAYERSCUSTOM][MAXAURAS];

That is right!  Its a boolean!

I've changed it so that it now allows levels to be compared correctly.

I've kept the system backwards compatible so that Luna could continue to use Easy Buffs.   I have not updated the Easy Buff system for the updated new Aura system.   The easy buff system still uses the backwards compatible system which only is able to use a registered distance value set on the race itself.

The new system can handle distance changes during the operation of the race.   This allows a race to have distance levels for more flexibility.

Three new natives:

// Use below to register, set, and remove your auras for the new system.
// you can "reregister the aura to switch the trackotherteam" using this system
native W3RegisterChangingDistanceAura(String:auraShortName[],bool:trackotherteam=false);

//removed if player disconnects
//level (optional) is a integer for a priority system, such as teammate has level 1 heal wave and another teammate has level 4 heal wave
//the player recieves the level 4 heal wave and does not stack with level 1 heal wave
//the distance for the aura of the client
native W3SetPlayerAura(tAuraID,client,Float:distance,level=0);

// A Simple Way to remove an aura from the player you had used SetAuraFromPlayer
native W3RemovePlayerAura(tAuraID,client);

I've updated ShadowHunter, Scout, and Fluttershy to handle the new system if you need examples on how to use it, just refer to those races.
