### PR TITLE
Fixed a bug that REDUCED health in races

### DIFF
--- a/addons/sourcemod/scripting/W3SIncs/War3Source_Health.inc
+++ b/addons/sourcemod/scripting/W3SIncs/War3Source_Health.inc
@@ -1,6 +1,6 @@
 /**
- * File: War3Source_Damage.inc
- * Description: Stocks regarding Damage
+ * File: War3Source_Health.inc
+ * Description: Stocks regarding health management
  * Author(s): War3Source Team  
  */
 
@@ -293,17 +293,21 @@ stock bool:War3_HealToMaxHP(client, health)
  */
 stock bool:War3HealToHP(client, addhp, maximumHP) {
     new currenthp = GetClientHealth(client);
-    new newhp = currenthp + addhp;
-    if (newhp > maximumHP) 
+    if(currenthp < maximumHP)
     {
-        newhp = maximumHP;
-    }
-    
-    SetEntityHealth(client, newhp);
-    if (currenthp < newhp)
-    {
-        War3_TFHealingEvent(client, newhp - currenthp);
-        return true;
+        new newhp = currenthp + addhp;
+        if (newhp > maximumHP) 
+        {
+            newhp = maximumHP;
+        }
+        
+        SetEntityHealth(client, newhp);
+        
+        if (currenthp < newhp)
+        {
+            War3_TFHealingEvent(client, newhp - currenthp);
+            return true;
+        }
     }
     return false;
 }


### PR DESCRIPTION
The healthtohp function was not respecting the situation where a race had MORE health than was passed as the maxHP value.  In other words, it was acting as a health overwrite than a heal function.
