### PR TITLE
Updated for what is known to low end boxing as "lag free technology"

### DIFF
--- a/addons/sourcemod/scripting/W3SIncs/War3Source_Races.inc
+++ b/addons/sourcemod/scripting/W3SIncs/War3Source_Races.inc
@@ -114,3 +114,10 @@ stock War3_GetRaceIDByName(const String:racename[64]) {
 native War3_RaceOnPluginStart(String:shortname[16]);
 native War3_RaceOnPluginEnd(String:shortname[16]);
 native bool:War3_IsRaceReloading();
+
+//=============================================================================
+// RACE Forwards
+//=============================================================================
+forward OnWar3RaceEnabled(newrace);
+forward OnWar3RaceDisabled(oldrace);
+

--- a/addons/sourcemod/scripting/War3Source_001_UndeadScourge.sp
+++ b/addons/sourcemod/scripting/War3Source_001_UndeadScourge.sp
@@ -13,6 +13,22 @@ public Plugin:myinfo =
 
 new thisRaceID;
 
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new Float:SuicideBomberRadius[5] = {0.0, 250.0, 290.0, 310.0, 333.0}; 
 new Float:SuicideBomberDamage[5] = {0.0, 166.0, 200.0, 233.0, 266.0};
 new Float:SuicideBomberDamageTF[5] = {0.0, 133.0, 175.0, 250.0, 300.0}; 
@@ -48,6 +64,11 @@ public OnWar3LoadRaceOrItemOrdered(num)
 
 public OnUltimateCommand(client, race, bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(pressed && War3_GetRace(client) == thisRaceID && IsPlayerAlive(client) && !Silenced(client))
     {
         new ult_level = War3_GetSkillLevel(client, race, SKILL_SUICIDE);
@@ -57,6 +78,11 @@ public OnUltimateCommand(client, race, bool:pressed)
 
 public OnWar3EventDeath(victim, attacker)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new race = W3GetVar(DeathRace);
     new skill = War3_GetSkillLevel(victim, thisRaceID, SKILL_SUICIDE);
     if(race == thisRaceID && skill > 0 && !Hexed(victim))

--- a/addons/sourcemod/scripting/War3Source_002_HumanAlliance.sp
+++ b/addons/sourcemod/scripting/War3Source_002_HumanAlliance.sp
@@ -12,6 +12,22 @@ public Plugin:myinfo =
 
 new thisRaceID;
 
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new Handle:ultCooldownCvar;
 
 // Chance/Info Arrays
@@ -104,10 +120,20 @@ public OnMapStart()
 
 public OnWar3EventSpawn(client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     ActivateSkills(client); //DO NOT OPTIMIZE, ActivateSkills checks for skill level
 }
 public ActivateSkills(client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new skill_devo=War3_GetSkillLevel(client,thisRaceID,SKILL_HEALTH);
     if(skill_devo)
     {
@@ -132,18 +158,23 @@ public ActivateSkills(client)
 }
 
 
-public OnGenericSkillLevelChanged(client,generic_skill_id,newlevel,Handle:generic_Skill_Options,customer_race,customer_skill)
-{
+//public OnGenericSkillLevelChanged(client,generic_skill_id,newlevel,Handle:generic_Skill_Options,customer_race,customer_skill)
+//{
     //new String:name[32];
     //GetClientName(client,name,sizeof(name));
     //DP("client %d %s genericskill %d level %d, cus %d %d",client,name,generic_skill_id,newlevel,customer_race,customer_skill);
-}
+//}
 
 new TPFailCDResetToRace[MAXPLAYERSCUSTOM];
 new TPFailCDResetToSkill[MAXPLAYERSCUSTOM];
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     //DP("ult pressed");
     if( pressed  && ValidPlayer(client,true) && !Silenced(client))
     {
@@ -183,6 +214,11 @@ public OnUltimateCommand(client,race,bool:pressed)
 
 public OnSkillLevelChanged(client,race,skill,newskilllevel)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(race==thisRaceID)
     {
         ActivateSkills(client); //on a race change, this is called 4 times, but that performance hit is insignificant
@@ -201,6 +237,11 @@ public OnSkillLevelChanged(client,race,skill,newskilllevel)
 
 bool:Teleport(client,Float:distance)
 {
+    if(RaceDisabled)
+    {
+        return false;
+    }
+
     if(!inteleportcheck[client])
     {
         
@@ -278,6 +319,11 @@ bool:Teleport(client,Float:distance)
     return false;
 }
 public Action:checkTeleport(Handle:h,any:client){
+    if(RaceDisabled)
+    {
+        return Plugin_Handled;
+    }
+
     inteleportcheck[client]=false;
     new Float:pos[3];
     
@@ -297,6 +343,7 @@ public Action:checkTeleport(Handle:h,any:client){
         PrintHintText(client,"%T","Teleported",client);
         
     }
+    return Plugin_Continue;
 }
 public bool:AimTargetFilter(entity,mask)
 {
@@ -307,7 +354,11 @@ public bool:AimTargetFilter(entity,mask)
 new absincarray[]={0,4,-4,8,-8,12,-12,18,-18,22,-22,25,-25};//,27,-27,30,-30,33,-33,40,-40}; //for human it needs to be smaller
 
 public bool:getEmptyLocationHull(client,Float:originalpos[3]){
-    
+    if(RaceDisabled)
+    {
+        return false;
+    }
+
     
     new Float:mins[3];
     new Float:maxs[3];
@@ -355,11 +406,16 @@ public bool:getEmptyLocationHull(client,Float:originalpos[3]){
         }
         
     }
-    
+    return true;
 } 
 
 public bool:CanHitThis(entityhit, mask, any:data)
 {
+    if(RaceDisabled)
+    {
+        return false;
+    }
+
     if(entityhit == data )
     {// Check if the TraceRay hit the itself.
         return false; // Don't allow self to be hit, skip this result
@@ -373,6 +429,11 @@ public bool:CanHitThis(entityhit, mask, any:data)
 
 public bool:enemyImmunityInRange(client,Float:playerVec[3])
 {
+    if(RaceDisabled)
+    {
+        return false;
+    }
+
     //ELIMINATE ULTIMATE IF THERE IS IMMUNITY AROUND
     new Float:otherVec[3];
     new team = GetClientTeam(client);

--- a/addons/sourcemod/scripting/War3Source_003_OrcishHorde.sp
+++ b/addons/sourcemod/scripting/War3Source_003_OrcishHorde.sp
@@ -23,6 +23,23 @@ public Plugin:myinfo =
 };
 
 new thisRaceID;
+
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new bool:bHasRespawned[MAXPLAYERSCUSTOM]; //cs
 new Handle:RespawnDelayCvar;
 new Handle:ultCooldownCvar;
@@ -120,6 +137,11 @@ public OnMapStart()
 
 public OnRaceChanged(client,oldrace,newrace)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(oldrace==thisRaceID && War3_GetGame()==Game_TF)
     {
         War3_SetBuff(client,fInvisibilitySkill,thisRaceID,1.0); // for tf2, remove alpha
@@ -132,6 +154,11 @@ public OnRaceChanged(client,oldrace,newrace)
 
 public DoChain(client,Float:distance,dmg,bool:first_call,last_target)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new target=0;
     new Float:target_dist=distance+1.0; // just an easy way to do this
     new caster_team=GetClientTeam(client);
@@ -195,6 +222,11 @@ public DoChain(client,Float:distance,dmg,bool:first_call,last_target)
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     //DP("ZthisRaceID:%d race race %d %d alive %d",thisRaceID,race,War3_GetRace(client),IsPlayerAlive(client));
     if(race==thisRaceID && pressed && IsPlayerAlive(client))
     {
@@ -224,6 +256,11 @@ public OnUltimateCommand(client,race,bool:pressed)
 
 public OnAbilityCommand(client,ability,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(War3_GetGame()==Game_TF && War3_GetRace(client)==thisRaceID && ability==0 && pressed && IsPlayerAlive(client))
     {
         new skill_level=War3_GetSkillLevel(client,thisRaceID,SKILL_RECARN_WARD);
@@ -247,6 +284,11 @@ public OnAbilityCommand(client,ability,bool:pressed)
 
 public OnSkillLevelChanged(client,race,skill,newskilllevel)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(War3_GetGame()==Game_TF&&race==thisRaceID&&skill==SKILL_NADE_INVIS&&newskilllevel>=0&&War3_GetRace(client)==thisRaceID)
     {
         new Float:alpha=WindWalkAlpha[newskilllevel];
@@ -277,6 +319,11 @@ public OnSkillLevelChanged(client,race,skill,newskilllevel)
 
 public OnWar3EventSpawn(client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     for(new x=1;x<=MaxClients;x++)
         bBeenHit[client][x]=false;
     
@@ -297,6 +344,11 @@ new damagestackcritmatch=-1;
 new Float:critpercent=0.0;
 public OnW3TakeDmgBulletPre(victim,attacker,Float:damage)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(IS_PLAYER(victim)&&IS_PLAYER(attacker)&&victim>0&&attacker>0&&attacker!=victim)
     {
         new vteam=GetClientTeam(victim);
@@ -327,6 +379,11 @@ public OnW3TakeDmgBulletPre(victim,attacker,Float:damage)
 //need event for weapon string
 public OnWar3EventPostHurt(victim, attacker, Float:damage, const String:weapon[32], bool:isWarcraft)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(victim>0&&attacker>0&&victim!=attacker)
     {
         new race_attacker=War3_GetRace(attacker);
@@ -423,7 +480,12 @@ public OnWar3EventPostHurt(victim, attacker, Float:damage, const String:weapon[3
 
 
 public OnWar3EventDeath(index,attacker)
-{    
+{
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(index)){
         new race=W3GetVar(DeathRace); //get  immediate variable, which indicates the race of the player when he died
         if(race==thisRaceID&&!bHasRespawned[index]&&War3_GetGame()!=Game_TF)
@@ -448,6 +510,11 @@ public OnWar3EventDeath(index,attacker)
 
 public Action:RespawnPlayer(Handle:timer,any:client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(client)&&!IsPlayerAlive(client)&&GetClientTeam(client)>1)
     {
         War3_SpawnPlayer(client);
@@ -504,12 +571,22 @@ public Action:RespawnPlayer(Handle:timer,any:client)
 
 public RoundStartEvent(Handle:event,const String:name[],bool:dontBroadcast)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     for(new x=1;x<=64;x++)
         bHasRespawned[x]=false;
 }
 
 public Action:DeciSecondTimer(Handle:h)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(War3_GetGame()==Game_TF){
         
         for(new x=1;x<=MaxClients;x++)

--- a/addons/sourcemod/scripting/War3Source_004_NightElf.sp
+++ b/addons/sourcemod/scripting/War3Source_004_NightElf.sp
@@ -5,6 +5,22 @@
 #include <sdktools>
 new thisRaceID;
 
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 public Plugin:myinfo =
 {
     name = "War3Source - Race - Night Elf",
@@ -67,6 +83,11 @@ public bool:AimTargetFilter(entity,mask)
 
 public bool:ImmunityCheck(client)
 {
+    if(RaceDisabled)
+    {
+        return false;
+    }
+
     if(bIsEntangled[client] || W3HasImmunity(client, Immunity_Ultimates))
     {
         return false;
@@ -77,6 +98,11 @@ public bool:ImmunityCheck(client)
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(race == thisRaceID && ValidPlayer(client, true) && pressed)
     {
         new iEntangleLevel = War3_GetSkillLevel(client, race, ULT_ENTANGLE);
@@ -149,6 +175,11 @@ public Action:StopEntangle(Handle:timer, any:client)
 
 public OnWar3EventSpawn(client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(bIsEntangled[client])
     {
         Untangle(client);
@@ -157,6 +188,11 @@ public OnWar3EventSpawn(client)
 
 public OnW3TakeDmgBulletPre(victim, attacker, Float:damage)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(attacker != victim)
     {
         // Trueshot
@@ -180,6 +216,11 @@ public OnW3TakeDmgBulletPre(victim, attacker, Float:damage)
 
 public OnWar3EventPostHurt(victim, attacker, Float:damage, const String:weapon[32], bool:isWarcraft)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(!isWarcraft && ValidPlayer(victim) && victim != attacker && War3_GetRace(victim) == thisRaceID)
     {
         new iThornsLevel = War3_GetSkillLevel(victim, thisRaceID, SKILL_THORNS );

--- a/addons/sourcemod/scripting/War3Source_005_BloodMage.sp
+++ b/addons/sourcemod/scripting/War3Source_005_BloodMage.sp
@@ -18,6 +18,22 @@ public Plugin:myinfo =
 
 new thisRaceID;
 
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new SKILL_REVIVE, SKILL_BANISH, SKILL_MONEYSTEAL,ULT_FLAMESTRIKE;
 
 //skill 1
@@ -151,6 +167,11 @@ public OnWar3PlayerAuthed(client)
 
 public Action:ResWarning(Handle:timer,any:userid)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     for(new client=1;client<=MaxClients;client++)
     {
         if(War3_GetGame()==Game_TF && RESwarn[client] && ValidPlayer(client))
@@ -163,11 +184,21 @@ public Action:ResWarning(Handle:timer,any:userid)
 
 public OnClientDisconnect(client)
 {
-	RESwarn[client]=false;
+    if(RaceDisabled)
+    {
+        return;
+    }
+
+    RESwarn[client]=false;
 }
 
 public OnRaceChanged(client,oldrace,newrace)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if( newrace!=thisRaceID)
     {
         new userid=GetClientUserId(client);
@@ -187,6 +218,11 @@ public OnRaceChanged(client,oldrace,newrace)
 new FireEntityEffect[MAXPLAYERSCUSTOM];
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new userid=GetClientUserId(client);
     if(race==thisRaceID && pressed && userid>1 && IsPlayerAlive(client) )
     {
@@ -249,10 +285,20 @@ public OnUltimateCommand(client,race,bool:pressed)
 }
 public bool:IsBurningFilter(client)
 {
+    if(RaceDisabled)
+    {
+        return false;
+    }
+
     return (BurnsRemaining[client]<=0 && !W3HasImmunity(client,Immunity_Ultimates));
 }
 public Action:BurnLoop(Handle:timer,any:userid)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new victim=GetClientOfUserId(userid);
     new attacker=GetClientOfUserId(BeingBurnedBy[victim]);
     if(victim>0 && attacker>0 && BurnsRemaining[victim]>0 && IsClientInGame(victim) && IsClientInGame(attacker) && IsPlayerAlive(victim))
@@ -277,7 +323,11 @@ public Action:BurnLoop(Handle:timer,any:userid)
 
 public OnSkillLevelChanged(client,race,skill,newskilllevel)
 {
-    
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(race==thisRaceID)
     {
         if(newskilllevel>=0)
@@ -302,16 +352,31 @@ public OnSkillLevelChanged(client,race,skill,newskilllevel)
 
 stock GetMoney(player)
 {
+    if(RaceDisabled)
+    {
+        return 0;
+    }
+
     return GetEntData(player,MoneyOffsetCS);
 }
 
 stock SetMoney(player,money)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     SetEntData(player,MoneyOffsetCS,money);
 }
 
 public OnW3TakeDmgBullet(victim,attacker,Float:damage)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(IS_PLAYER(victim)&&IS_PLAYER(attacker)&&attacker!=victim&&GetClientTeam(attacker)!=GetClientTeam(victim))
     {
         // W3IsOwnerSentry checks for game tf and returns false if not, so it should go thru if not game tf anyhow.
@@ -423,6 +488,11 @@ public OnW3TakeDmgBullet(victim,attacker,Float:damage)
 }
 
 stock siphonsfx(victim) {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     decl Float:vecAngles[3];
     GetClientEyeAngles(victim,vecAngles);
     decl Float:target_pos[3];
@@ -433,6 +503,11 @@ stock siphonsfx(victim) {
 }
 
 stock respawnsfx(target) {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new Float:effect_vec[3];
     GetClientAbsOrigin(target,effect_vec);
     effect_vec[2]+=15.0;
@@ -449,6 +524,11 @@ stock respawnsfx(target) {
 // Events
 public PlayerSpawnEvent(Handle:event,const String:name[],bool:dontBroadcast)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new userid=GetEventInt(event,"userid");
     new client=GetClientOfUserId(userid);
     if(client>0)
@@ -474,6 +554,11 @@ public PlayerSpawnEvent(Handle:event,const String:name[],bool:dontBroadcast)
 
 public RoundStartEvent(Handle:event,const String:name[],bool:dontBroadcast)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     
     for(new i=1;i<=MaxClients;i++)
     {
@@ -490,6 +575,11 @@ public RoundStartEvent(Handle:event,const String:name[],bool:dontBroadcast)
 
 public Action:DoRevival(Handle:timer,any:userid)
 {
+    if(RaceDisabled)
+    {
+        return Plugin_Handled;
+    }
+
     new client=GetClientOfUserId(userid);
     if(Can_Player_Revive[client]==false)
     {
@@ -596,6 +686,11 @@ public Action:DoRevival(Handle:timer,any:userid)
 
 bool:CooldownRevive(client)
 {
+    if(RaceDisabled)
+    {
+        return false;
+    }
+
     if(GetGameTime() >= (fLastRevive[client]+30.0))
         return true;
     return false;
@@ -603,6 +698,11 @@ bool:CooldownRevive(client)
 
 public PlayerTeamEvent(Handle:event,const String:name[],bool:dontBroadcast)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
 // Team Switch checker
     new userid=GetEventInt(event,"userid");
     new client=GetClientOfUserId(userid);
@@ -617,6 +717,11 @@ public PlayerTeamEvent(Handle:event,const String:name[],bool:dontBroadcast)
 
 public Action:PlayerCanRevive(Handle:timer,any:userid)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
 // Team Switch checker
     new client=GetClientOfUserId(userid);
     // For testing purposes:
@@ -628,6 +733,11 @@ public Action:PlayerCanRevive(Handle:timer,any:userid)
 
 public PlayerDeathEvent(Handle:event,const String:name[],bool:dontBroadcast)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new userid=GetEventInt(event,"userid");
     new victim=GetClientOfUserId(userid);
     if(victim>0)
@@ -702,6 +812,11 @@ public PlayerDeathEvent(Handle:event,const String:name[],bool:dontBroadcast)
 
 public Action:Unbanish(Handle:timer,any:userid)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     // never EVER use client in a timer. userid is safe
     new client=GetClientOfUserId(userid);
     if(client>0)
@@ -713,6 +828,11 @@ public Action:Unbanish(Handle:timer,any:userid)
 new absincarray[]={0,4,-4,8,-8,12,-12,18,-18,22,-22,25,-25,27,-27,30,-30};//,33,-33,40,-40};
 
 public bool:testhull(client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     
     //PrintToChatAll("BEG");
     new Float:mins[3];
@@ -776,6 +896,11 @@ public bool:testhull(client){
 
 public bool:CanHitThis(entityhit, mask, any:data)
 {
+    if(RaceDisabled)
+    {
+        return false;
+    }
+
     if(entityhit == data )
     {// Check if the TraceRay hit the itself.
         return false; // Don't allow self to be hit, skip this result

--- a/addons/sourcemod/scripting/War3Source_006_ShadowHunter.sp
+++ b/addons/sourcemod/scripting/War3Source_006_ShadowHunter.sp
@@ -17,6 +17,22 @@ public Plugin:myinfo =
 
 new thisRaceID;
 
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new SKILL_HEALINGWAVE, SKILL_HEX, SKILL_WARD, ULT_VOODOO;
 
 //skill 1
@@ -98,6 +114,11 @@ public OnWar3PlayerAuthed(client)
 
 public OnRaceChanged(client,oldrace,newrace)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(newrace==thisRaceID)
     {
         new level=War3_GetSkillLevel(client,thisRaceID,SKILL_HEALINGWAVE);
@@ -116,6 +137,11 @@ public OnRaceChanged(client,oldrace,newrace)
 
 public OnSkillLevelChanged(client,race,skill,newskilllevel)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     
     if(race==thisRaceID && War3_GetRace(client)==thisRaceID)
     {
@@ -132,6 +158,11 @@ public OnSkillLevelChanged(client,race,skill,newskilllevel)
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new userid=GetClientUserId(client);
     if(race==thisRaceID && pressed && userid>1 && IsPlayerAlive(client) )
     {
@@ -161,6 +192,11 @@ public OnUltimateCommand(client,race,bool:pressed)
 
 public Action:EndVoodoo(Handle:timer,any:client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     bVoodoo[client]=false;
     W3ResetPlayerColor(client,thisRaceID);
     if(ValidPlayer(client,true))
@@ -171,6 +207,11 @@ public Action:EndVoodoo(Handle:timer,any:client)
 
 public OnAbilityCommand(client,ability,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(War3_GetRace(client)==thisRaceID && ability==0 && pressed && IsPlayerAlive(client))
     {
         new skill_level=War3_GetSkillLevel(client,thisRaceID,SKILL_WARD);
@@ -231,6 +272,11 @@ public OnAbilityCommand(client,ability,bool:pressed)
 
 public OnW3TakeDmgAllPre(victim,attacker,Float:damage)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(IS_PLAYER(victim)&&IS_PLAYER(attacker)&&victim>0&&attacker>0) //block self inflicted damage
     {
         if(bVoodoo[victim]&&attacker==victim){
@@ -267,6 +313,11 @@ public OnW3TakeDmgAllPre(victim,attacker,Float:damage)
 
 // Events
 public OnWar3EventSpawn(client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     bVoodoo[client]=false;
     StopParticleEffect(client, true);
 }
@@ -278,11 +329,21 @@ public OnClientDisconnect(client)
 
 public OnWar3EventDeath(victim, attacker)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     StopParticleEffect(victim, false);
 }
 
 public Action:CalcHexHealWaves(Handle:timer,any:userid)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(thisRaceID>0)
     {
         for(new i=1;i<=MaxClients;i++)
@@ -301,6 +362,11 @@ public Action:CalcHexHealWaves(Handle:timer,any:userid)
 }
 public OnW3PlayerAuraStateChanged(client,aura,bool:inAura,level)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(aura==AuraID)
     {
         //DP(inAura?"[SH] in aura":"[SH] not in aura");

--- a/addons/sourcemod/scripting/War3Source_007_Warden.sp
+++ b/addons/sourcemod/scripting/War3Source_007_Warden.sp
@@ -16,6 +16,22 @@ public Plugin:myinfo =
 
 new thisRaceID;
 
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new String:sOldModel[MAXPLAYERSCUSTOM][256];
 new OriginOffset;
 
@@ -118,11 +134,21 @@ public OnMapStart()
 }
 
 public OnWar3EventSpawn(client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     StrikesRemaining[client]=0;
 }
 
 public OnRaceChanged(client,oldrace,newrace)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(newrace!=thisRaceID)
     {    
         War3_SetBuff(client,bImmunityUltimates,thisRaceID,false);
@@ -133,6 +159,11 @@ public OnRaceChanged(client,oldrace,newrace)
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     // TODO: Increment UltimateUsed[client]
     if(race==thisRaceID && pressed && IsPlayerAlive(client))
     {
@@ -180,6 +211,11 @@ public OnUltimateCommand(client,race,bool:pressed)
 
 public OnW3TakeDmgBullet(victim,attacker,Float:damage)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(IS_PLAYER(victim)&&IS_PLAYER(attacker)&&victim>0&&attacker>0&&attacker!=victim)
     {
         if(IsPlayerAlive(attacker)&&IsPlayerAlive(victim)&&GetClientTeam(victim)!=GetClientTeam(attacker))
@@ -280,6 +316,11 @@ public OnW3TakeDmgBullet(victim,attacker,Float:damage)
 }
 public Action:ShadowStrikeLoop(Handle:timer,any:userid)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new victim = GetClientOfUserId(userid);
     if(StrikesRemaining[victim]>0 && ValidPlayer(BeingStrikedBy[victim]) && ValidPlayer(victim,true))
     {
@@ -296,6 +337,11 @@ public Action:ShadowStrikeLoop(Handle:timer,any:userid)
 
 stock TE_SetupDynamicLight(const Float:vecOrigin[3], r,g,b,iExponent,Float:fRadius,Float:fTime,Float:fDecay)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     TE_Start("Dynamic Light");
     TE_WriteVector("m_vecOrigin",vecOrigin);
     TE_WriteNum("r",r);
@@ -309,6 +355,11 @@ stock TE_SetupDynamicLight(const Float:vecOrigin[3], r,g,b,iExponent,Float:fRadi
 
 public RoundStartEvent(Handle:event,const String:name[],bool:dontBroadcast)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     for(new i=1;i<=MaxClients;i++)
     {
         ultUsedTimes[i]=0;
@@ -330,12 +381,22 @@ public RoundStartEvent(Handle:event,const String:name[],bool:dontBroadcast)
 
 public StartMole(client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new Float:mole_time=5.0;
     W3MsgMoleIn(client,mole_time);
     CreateTimer(0.2+mole_time,DoMole,client);
 }
 public Action:DoMole(Handle:timer,any:client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(client,true))
     {
         new team=GetClientTeam(client);
@@ -394,6 +455,11 @@ public Action:DoMole(Handle:timer,any:client)
 }
 public Action:ResetModel(Handle:timer,any:client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(client,true))
     {
         SetEntityModel(client,sOldModel[client]);
@@ -405,6 +471,11 @@ public Action:ResetModel(Handle:timer,any:client)
 
 public Action:CalcBlink(Handle:timer,any:userid)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(thisRaceID>0)
     {
         for(new i=1;i<=MaxClients;i++)
@@ -420,6 +491,11 @@ public Action:CalcBlink(Handle:timer,any:userid)
 
 public PlayerDeathEvent(Handle:event,const String:name[],bool:dontBroadcast)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new victim=GetClientOfUserId(GetEventInt(event,"userid"));
     new attacker=GetClientOfUserId(GetEventInt(event,"attacker"));
     new bool:should_vengence=false;
@@ -486,6 +562,11 @@ public PlayerDeathEvent(Handle:event,const String:name[],bool:dontBroadcast)
 
 public GiveDeathWeapons(client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(client>0)
     {
         // reincarnate with weapons
@@ -530,6 +611,11 @@ public GiveDeathWeapons(client)
 
 public Action:VengenceRespawn(Handle:t,any:userid)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new client=GetClientOfUserId(userid);
     if(client>0 && War3_GetRace(client)==thisRaceID) //did he become alive?
     {
@@ -572,6 +658,11 @@ public Action:VengenceRespawn(Handle:t,any:userid)
 
 public bool:blockingVengence(client)  //TF2 only
 {
+    if(RaceDisabled)
+    {
+        return true;
+    }
+
     //ELIMINATE ULTIMATE IF THERE IS IMMUNITY AROUND
     new Float:playerVec[3];
     GetClientAbsOrigin(client,playerVec);

--- a/addons/sourcemod/scripting/War3Source_008_CryptLord.sp
+++ b/addons/sourcemod/scripting/War3Source_008_CryptLord.sp
@@ -16,6 +16,22 @@ public Plugin:myinfo =
 
 new thisRaceID;
 
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new SKILL_IMPALE,SKILL_SPIKE,SKILL_BEETLES,ULT_LOCUST;
 
 //skill 1
@@ -69,6 +85,10 @@ public OnMapStart()
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
 
     if(race==thisRaceID && pressed && ValidPlayer(client,true) )
     {
@@ -133,6 +153,11 @@ public OnUltimateCommand(client,race,bool:pressed)
 
 
 public OnW3TakeDmgBulletPre(victim,attacker,Float:damage){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(victim,true)&&ValidPlayer(attacker,true)&&GetClientTeam(victim)!=GetClientTeam(attacker))
     {
         if(War3_GetRace(victim)==thisRaceID)
@@ -147,6 +172,11 @@ public OnW3TakeDmgBulletPre(victim,attacker,Float:damage){
 }
 public OnWar3EventPostHurt(victim, attacker, Float:damage, const String:weapon[32], bool:isWarcraft)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(!isWarcraft&&ValidPlayer(victim,true)&&ValidPlayer(attacker,true)&&GetClientTeam(victim)!=GetClientTeam(attacker))
     {
     

--- a/addons/sourcemod/scripting/War3Source_009_CorruptedDisciple.sp
+++ b/addons/sourcemod/scripting/War3Source_009_CorruptedDisciple.sp
@@ -17,6 +17,23 @@ public Plugin:myinfo =
 };
 
 new thisRaceID;
+
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new Handle:ultCooldownCvar;
 
 new SKILL_TIDE, SKILL_CONDUIT, SKILL_STATIC, ULT_OVERLOAD;
@@ -115,6 +132,11 @@ public OnMapStart()
 
 public OnAbilityCommand(client,ability,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(/*War3_GetRace(client)==thisRaceID &&*/ ability==0 && pressed && ValidPlayer(client, true))
     {
         new skill_level=War3_GetSkillLevel(client,thisRaceID,SKILL_TIDE);
@@ -153,12 +175,22 @@ public OnAbilityCommand(client,ability,bool:pressed)
 
 public Action:SecondRing(Handle:timer,any:userid)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new client=GetClientOfUserId(userid);
     TE_SetupBeamRingPoint(ElectricTideOrigin[client], ElectricTideRadius+50,20.0, BeamSprite, HaloSprite, 0, 5, 0.5, 10.0, 1.0, {255,0,255,133}, 60, 0);
     TE_SendToAll();
 }
 public Action:BurnLoop(Handle:timer,any:userid)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new attacker=GetClientOfUserId(userid);
     if(ValidPlayer(attacker) && ElectricTideLoopCountdown[attacker]>0)
     {
@@ -213,10 +245,20 @@ public Action:BurnLoop(Handle:timer,any:userid)
 
 
 public OnWar3EventSpawn(client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     UltimateZapsRemaining[client]=0;
 }
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(race==thisRaceID && pressed && IsPlayerAlive(client))
     {
         //if(
@@ -249,6 +291,11 @@ public OnUltimateCommand(client,race,bool:pressed)
 }
 public Action:UltimateLoop(Handle:timer,any:userid)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new attacker=GetClientOfUserId(userid);
     if(ValidPlayer(attacker) && UltimateZapsRemaining[attacker]>0&&IsPlayerAlive(attacker))
     {
@@ -319,6 +366,11 @@ public Action:UltimateLoop(Handle:timer,any:userid)
     }
 }
 public Action:UltStateSound(Handle:t,any:attacker){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(attacker,true)&&UltimateZapsRemaining[attacker]>0){
         W3EmitSoundToAll(overloadstate,attacker);
         CreateTimer(3.7,UltStateSound,attacker);
@@ -327,6 +379,11 @@ public Action:UltStateSound(Handle:t,any:attacker){
 
 public bool:CanHitThis(entity, mask, any:data)
 {
+    if(RaceDisabled)
+    {
+        return false;
+    }
+
     if(entity == data)
     {// Check if the TraceRay hit the itself.
         return false; // Don't allow self to be hit
@@ -342,6 +399,11 @@ public bool:CanHitThis(entity, mask, any:data)
 
 public OnW3TakeDmgAllPre(victim,attacker,Float:damage)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(IS_PLAYER(victim)&&IS_PLAYER(attacker)&&victim>0&&attacker>0&&attacker!=victim)
     {
         new vteam=GetClientTeam(victim);
@@ -365,6 +427,11 @@ public OnW3TakeDmgAllPre(victim,attacker,Float:damage)
 
 public PlayerHurtEvent(Handle:event,const String:name[],bool:dontBroadcast)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new userid=GetEventInt(event,"userid");
     new attacker_userid=GetEventInt(event,"attacker");
     new dmg=GetEventInt(event,"dmg_health");
@@ -461,6 +528,11 @@ public PlayerHurtEvent(Handle:event,const String:name[],bool:dontBroadcast)
 
 public Action:CalcConduit(Handle:timer,any:userid)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new Float:time = GetGameTime();
     for(new i=1;i<=MaxClients;i++){
         if(time>ConduitUntilTime[i]){
@@ -471,6 +543,11 @@ public Action:CalcConduit(Handle:timer,any:userid)
     }
 }
 public OnClientPutInServer(i){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     ConduitBy[i]=0;
     ConduitUntilTime[i]=0.0;
     ConduitSubtractDamage[i]=0;

--- a/addons/sourcemod/scripting/War3Source_010_SoulReaper.sp
+++ b/addons/sourcemod/scripting/War3Source_010_SoulReaper.sp
@@ -16,6 +16,23 @@ public Plugin:myinfo =
 };
 
 new thisRaceID;
+
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new Handle:ultCooldownCvar;
 
 new SKILL_JUDGE, SKILL_PRESENCE,SKILL_INHUMAN, ULT_EXECUTE;
@@ -78,6 +95,11 @@ public OnMapStart()
 
 public OnAbilityCommand(client,ability,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(War3_GetRace(client)==thisRaceID && ability==0 && pressed && IsPlayerAlive(client))
     {
         new skill_level=War3_GetSkillLevel(client,thisRaceID,SKILL_JUDGE);
@@ -121,6 +143,11 @@ public OnAbilityCommand(client,ability,bool:pressed)
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(race==thisRaceID && pressed && IsPlayerAlive(client))
     {
         //if(
@@ -163,6 +190,11 @@ public OnUltimateCommand(client,race,bool:pressed)
 
 public PlayerDeathEvent(Handle:event,const String:name[],bool:dontBroadcast)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new userid=GetEventInt(event,"userid");
     new victim=GetClientOfUserId(userid);
     

--- a/addons/sourcemod/scripting/War3Source_011_BloodHunter.sp
+++ b/addons/sourcemod/scripting/War3Source_011_BloodHunter.sp
@@ -11,6 +11,23 @@ public Plugin:myinfo =
 };
 
 new thisRaceID;
+
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new Handle:ultCooldownCvar;
 
 new SKILL_CRAZY, SKILL_FEAST,SKILL_SENSE,ULT_RUPTURE;
@@ -66,6 +83,11 @@ public OnMapStart()
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(race == thisRaceID && pressed && ValidPlayer(client, true))
     {
         new skill = War3_GetSkillLevel(client, race, ULT_RUPTURE);
@@ -104,12 +126,22 @@ public OnUltimateCommand(client,race,bool:pressed)
 
 public OnWar3EventSpawn(client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     bRuptured[client] = false;
     bCrazyDot[client] = false;
 }
 
 public OnWar3EventDeath(victim, attacker)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(attacker,true))
     {
         if(War3_GetRace(attacker) == thisRaceID)
@@ -126,6 +158,11 @@ public OnWar3EventDeath(victim, attacker)
 
 public Action:RuptureCheckLoop(Handle:h, any:data)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new Float:origin[3];
     new attacker;
     new skilllevel;
@@ -183,6 +220,11 @@ public Action:RuptureCheckLoop(Handle:h, any:data)
 }
 public Action:BloodCrazyDOTLoop(Handle:h,any:data)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new attacker;
     for(new i=1; i <= MaxClients; i++)
     {
@@ -221,6 +263,11 @@ public Action:BloodCrazyDOTLoop(Handle:h,any:data)
 
 public OnW3EnemyTakeDmgBulletPre(victim,attacker,Float:damage)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(!W3IsOwnerSentry(attacker) && War3_GetRace(attacker) == thisRaceID && !Hexed(attacker, false) && !W3HasImmunity(victim,Immunity_Skills))
     {
         new skilllevel = War3_GetSkillLevel(attacker, thisRaceID, SKILL_CRAZY);
@@ -246,12 +293,22 @@ public OnW3EnemyTakeDmgBulletPre(victim,attacker,Float:damage)
 
 public Gore(client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     WriteParticle(client, "blood_spray_red_01_far");
     WriteParticle(client, "blood_impact_red_01");
 }
 
 WriteParticle(client, String:ParticleName[])
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     decl Float:fPos[3], Float:fAngles[3];
 
     fAngles[0] = GetRandomFloat(0.0, 360.0);

--- a/addons/sourcemod/scripting/War3Source_012_Naix.sp
+++ b/addons/sourcemod/scripting/War3Source_012_Naix.sp
@@ -34,6 +34,22 @@ new Handle:ultCooldownCvar;
 
 new thisRaceID, SKILL_INFEST, SKILL_BLOODBATH, SKILL_FEAST, ULT_RAGE;
 
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new String:skill1snd[256]; //="war3source/naix/predskill1.mp3";
 new String:ultsnd[256]; //="war3source/naix/predult.mp3";
 
@@ -60,8 +76,12 @@ public OnWar3LoadRaceOrItemOrdered(num)
 }
 
 stock bool:IsOurRace(client) {
+    if(RaceDisabled)
+    {
+        return false;
+    }
 
-  return (War3_GetRace(client)==thisRaceID);
+    return (War3_GetRace(client)==thisRaceID);
 }
 
 
@@ -76,6 +96,11 @@ public OnMapStart()
 
 public OnWar3EventPostHurt(victim, attacker, Float:damage, const String:weapon[32], bool:isWarcraft)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(victim)&&W3Chance(W3ChanceModifier(attacker))&&ValidPlayer(attacker)&&IsOurRace(attacker)&&victim!=attacker&&GetClientTeam(attacker)!=GetClientTeam(victim)){
         new level = War3_GetSkillLevel(attacker, thisRaceID, SKILL_FEAST);
         if(level>0&&!Hexed(attacker,false)&&W3Chance(W3ChanceModifier(attacker))){
@@ -91,6 +116,11 @@ public OnWar3EventPostHurt(victim, attacker, Float:damage, const String:weapon[3
     }
 }
 public OnWar3EventSpawn(client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(IsOurRace(client)){
         new level = War3_GetSkillLevel(client, thisRaceID, SKILL_BLOODBATH);
         if(level>=0){ //zeroth level passive
@@ -111,12 +141,22 @@ public OnRaceChanged(client,oldrace,newrace)
 }*/
 public Action:OnPlayerRunCmd(client, &buttons, &impulse, Float:vel[3], Float:angles[3], &weapon)
 {
+    if(RaceDisabled)
+    {
+        return Plugin_Continue;
+    }
+
     
     bDucking[client]=(buttons & IN_DUCK)?true:false;
     return Plugin_Continue;
 }
 //new Float:teleportTo[66][3];
 public OnWar3EventDeath(victim,attacker){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(victim)&&ValidPlayer(attacker)&&IsOurRace(attacker)){
         new iSkillLevel=War3_GetSkillLevel(attacker,thisRaceID,SKILL_INFEST);
         if (iSkillLevel>0)
@@ -167,6 +207,11 @@ public Action:setlocation(Handle:t,any:attacker){
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(race==thisRaceID && pressed && ValidPlayer(client,true))
     {
         new ultLevel=War3_GetSkillLevel(client,thisRaceID,ULT_RAGE);
@@ -202,6 +247,11 @@ public OnUltimateCommand(client,race,bool:pressed)
     }
 }
 public Action:stopRage(Handle:t,any:client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     War3_SetBuff(client,fAttackSpeed,thisRaceID,1.0);
     if(ValidPlayer(client,true)){
         PrintHintText(client,"%T","You are no longer in rage mode",client);

--- a/addons/sourcemod/scripting/War3Source_013_SuccubusHunter.sp
+++ b/addons/sourcemod/scripting/War3Source_013_SuccubusHunter.sp
@@ -16,6 +16,23 @@ public Plugin:myinfo =
 };
 
 new thisRaceID, SKILL_HEADHUNTER, SKILL_TOTEM, SKILL_ASSAULT, ULT_TRANSFORM;
+
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new m_iAccount = -1,m_vecVelocity_0, m_vecVelocity_1, m_vecBaseVelocity; //offsets
 
 
@@ -81,12 +98,22 @@ public OnPluginStart()
     LoadTranslations("w3s.race.succubus.phrases");
 }
 public OnRaceChanged(client,oldrace,newrace){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(oldrace==thisRaceID){
         War3_SetBuff(client,iAdditionalMaxHealth,thisRaceID,0);
     }
 }
 public OnWar3EventSpawn(client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new race=War3_GetRace(client); 
     if (race==thisRaceID) 
     {
@@ -209,6 +236,11 @@ public OnWar3EventSpawn(client)
 
 public OnWar3EventPostHurt(victim, attacker, Float:damage, const String:weapon[32], bool:isWarcraft)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(!isWarcraft && ValidPlayer(victim, true, true) && ValidPlayer(attacker) && victim != attacker && GetClientTeam( victim ) != GetClientTeam( attacker ))
     {
         new skilllevelheadhunter = War3_GetSkillLevel(attacker, thisRaceID, SKILL_HEADHUNTER);
@@ -316,6 +348,11 @@ public PlayerHurtEvent(Handle:event,const String:name[],bool:dontBroadcast)
 }
 */
 public OnWar3EventDeath(victim,attacker){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new skilllevelheadhunter=War3_GetSkillLevel(attacker,thisRaceID,SKILL_HEADHUNTER);
     if (skilllevelheadhunter &&!Hexed(attacker)&&victim!=attacker)
     {
@@ -437,6 +474,11 @@ DP("death");
 */
 public PlayerJumpEvent(Handle:event,const String:name[],bool:dontBroadcast)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new client=GetClientOfUserId(GetEventInt(event,"userid"));
     new race=War3_GetRace(client);
     if (race==thisRaceID)
@@ -502,6 +544,11 @@ public PlayerJumpEvent(Handle:event,const String:name[],bool:dontBroadcast)
 
 public Action:OnPlayerRunCmd(client, &buttons, &impulse, Float:vel[3], Float:angles[3], &weapon)
 {
+    if(RaceDisabled)
+    {
+        return Plugin_Continue;
+    }
+
 
     if (!GAMECSANY && (buttons & IN_JUMP)) //assault for non CS games
     {
@@ -621,6 +668,11 @@ public OnClientPutInServer(client)
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(client,true)&&pressed && race==thisRaceID)
     {
         new skill_trans=War3_GetSkillLevel(client,race,ULT_TRANSFORM);
@@ -660,6 +712,11 @@ public OnUltimateCommand(client,race,bool:pressed)
 
 public Action:Finishtrans(Handle:timer,any:client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     
     if(m_IsULT_TRANSFORMformed[client]){
         War3_SetBuff(client,fMaxSpeed,thisRaceID,1.0);

--- a/addons/sourcemod/scripting/War3Source_014_Chronos.sp
+++ b/addons/sourcemod/scripting/War3Source_014_Chronos.sp
@@ -13,6 +13,22 @@ public Plugin:myinfo =
 
 new thisRaceID;
 
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new m_vecVelocity_0, m_vecVelocity_1, m_vecBaseVelocity; //offsets
 
 new bool:bTrapped[MAXPLAYERSCUSTOM];
@@ -101,6 +117,11 @@ public OnWar3LoadRaceOrItemOrdered(num)
 
 public PlayerJumpEvent(Handle:event,const String:name[],bool:dontBroadcast)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new client=GetClientOfUserId(GetEventInt(event,"userid"));
 
     if(ValidPlayer(client,true)){
@@ -134,6 +155,11 @@ public PlayerJumpEvent(Handle:event,const String:name[],bool:dontBroadcast)
 
 public Action:OnPlayerRunCmd(client, &buttons, &impulse, Float:vel[3], Float:angles[3], &weapon)
 {
+    if(RaceDisabled)
+    {
+        return Plugin_Continue;
+    }
+
 
     if (!GAMECSANY && (buttons & IN_JUMP)) //assault for non CS games
     {
@@ -214,6 +240,11 @@ public Action:OnPlayerRunCmd(client, &buttons, &impulse, Float:vel[3], Float:ang
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(race==thisRaceID && IsPlayerAlive(client) && pressed)
     {
         new skill_level=War3_GetSkillLevel(client,race,ULT_SPHERE);
@@ -283,6 +314,11 @@ public OnUltimateCommand(client,race,bool:pressed)
     }
 }
 public Action:sphereLoop(Handle:h,any:client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(hasSphere[client]&&SphereEndTime[client]>GetGameTime()){
         new Float:victimpos[3];
         new team=GetClientTeam(client);
@@ -320,6 +356,11 @@ public Action:sphereLoop(Handle:h,any:client){
     
 }
 public Action:unBashUlt(Handle:h,any:client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     War3_SetBuff(client,bBashed,thisRaceID,false);
     War3_SetBuff(client,fAttackSpeed,thisRaceID,1.0);
     bTrapped[client]=false;
@@ -328,11 +369,21 @@ public Action:unBashUlt(Handle:h,any:client){
     
 }
 public Action:sphereend(Handle:h,any:client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     hasSphere[client]=false;
     
 }
 
 public OnW3TakeDmgAllPre(victim,attacker,Float:damage){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(bTrapped[victim]){ ///trapped people can only be damaged with knife
         if(ValidPlayer(attacker,true)){
             new wpnent = W3GetCurrentWeaponEnt(attacker);
@@ -382,6 +433,11 @@ public OnW3TakeDmgAllPre(victim,attacker,Float:damage){
     }
 }
 IsInOwnSphere(client){
+    if(RaceDisabled)
+    {
+        return false;
+    }
+
     if(hasSphere[client]){
         new Float:pos[3];
         GetClientEyePosition(client,pos);
@@ -394,6 +450,11 @@ IsInOwnSphere(client){
 
 public OnWar3EventPostHurt(victim, attacker, Float:damage, const String:weapon[32], bool:isWarcraft)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(victim,true)&&ValidPlayer(attacker,true) &&GetClientTeam(attacker)!=GetClientTeam(victim))
     {    
         
@@ -431,14 +492,29 @@ public OnWar3EventPostHurt(victim, attacker, Float:damage, const String:weapon[3
 
 public Action:UnfreezeStun(Handle:h,any:client) //always keep timer data generic
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     War3_SetBuff(client,bStunned,thisRaceID,false);
 }
 public OnWar3EventDeath(victim,attacker){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     RewindHPAmount[victim]=0;
 }
 new skip;
 public OnGameFrame() //this is a sourcemod forward?, every game frame it is called. forwards if u implement it sourcemod will call you
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(skip==0){
     
         for(new i=1;i<=MaxClients;i++){

--- a/addons/sourcemod/scripting/War3Source_015_Lich.sp
+++ b/addons/sourcemod/scripting/War3Source_015_Lich.sp
@@ -16,6 +16,22 @@ public Plugin:myinfo =
 
 new thisRaceID;
 
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new SKILL_FROSTNOVA,SKILL_FROSTARMOR,SKILL_DARKRITUAL,ULT_DEATHDECAY;
 
 //skill 1
@@ -82,6 +98,11 @@ public OnMapStart()
 
 public OnAbilityCommand(client,ability,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(War3_GetRace(client)==thisRaceID && ability==0 && pressed && IsPlayerAlive(client))
     {
         new skill_level=War3_GetSkillLevel(client,thisRaceID,SKILL_FROSTNOVA);
@@ -121,6 +142,11 @@ public OnAbilityCommand(client,ability,bool:pressed)
 
 public Action:BurnLoop(Handle:timer,any:attacker)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
 
     if(ValidPlayer(attacker) && FrostNovaLoopCountdown[attacker]>0)
     {
@@ -166,6 +192,11 @@ public Action:BurnLoop(Handle:timer,any:attacker)
     }
 }
 public Action:RemoveFrostNova(Handle:t,any:client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     War3_SetBuff(client,fSlow,thisRaceID,1.0);
     War3_SetBuff(client,fAttackSpeed,thisRaceID,1.0);
 }
@@ -202,6 +233,11 @@ public Action: farmor(Handle:timer,any:attacker)
 */    
 public OnWar3EventDeath(victim,attacker)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new team;
     if(ValidPlayer(victim)){
         team=GetClientTeam(victim);
@@ -229,6 +265,11 @@ public OnWar3EventDeath(victim,attacker)
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new userid=GetClientUserId(client);            
     if(race==thisRaceID && pressed && userid>1 && IsPlayerAlive(client) )
     {

--- a/addons/sourcemod/scripting/War3Source_016_SacredWarrior.sp
+++ b/addons/sourcemod/scripting/War3Source_016_SacredWarrior.sp
@@ -11,6 +11,23 @@ public Plugin:myinfo =
 };
 
 new thisRaceID;
+
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new SKILL_VITALITY, SKILL_SPEAR, SKILL_BLOOD, ULT_BREAK;
 
 // Inner Vitality, HP healed
@@ -59,7 +76,11 @@ public OnWar3LoadRaceOrItemOrdered(num)
 }
 public OnWar3EventSpawn(client)
 {
-    
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     VictimSpearStacks[client] = 0;  // deactivate Burning Spear
     VictimSpearTicks[client] = 0;
     bSpearActivated[client] = false;  // on spawn
@@ -68,6 +89,11 @@ public OnWar3EventSpawn(client)
 
 public Action:Heal_BurningSpearTimer(Handle:h,any:data) //1 sec
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new attacker;
     new damage;
     //new SelfDamage;
@@ -117,6 +143,11 @@ public Action:Heal_BurningSpearTimer(Handle:h,any:data) //1 sec
 
 public Action:BerserkerCalculateTimer(Handle:timer,any:userid) // Check each 0.5 second if the conditions for Berserkers Blood have changed
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(thisRaceID>0)
     {
         for(new i=1;i<=MaxClients;i++)
@@ -150,6 +181,11 @@ public Action:BerserkerCalculateTimer(Handle:timer,any:userid) // Check each 0.5
 }
 
 public OnW3TakeDmgBullet(victim,attacker,Float:damage){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(victim,true)&&ValidPlayer(attacker,false)&&GetClientTeam(victim)!=GetClientTeam(attacker))
     {
         if(War3_GetRace(attacker)==thisRaceID)
@@ -172,13 +208,28 @@ public OnW3TakeDmgBullet(victim,attacker,Float:damage){
     }
 }
 public OnSkillLevelChanged(client,race,skill,newskilllevel){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     CheckSkills(client);
 }
 public OnRaceChanged(client,oldrace,newrace)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     CheckSkills(client);
 }
 CheckSkills(client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(War3_GetRace(client)!=thisRaceID)
     {
         War3_SetBuff(client,fAttackSpeed,thisRaceID,1.0); // Remove ASPD buff when changing races
@@ -206,6 +257,11 @@ CheckSkills(client){
 
 public OnAbilityCommand(client,ability,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new skill = War3_GetSkillLevel(client, thisRaceID, SKILL_SPEAR);
     if(skill>0 && War3_GetRace(client)==thisRaceID && ability==0 && pressed && IsPlayerAlive(client)&&!Silenced(client))
     {
@@ -229,7 +285,11 @@ public OnAbilityCommand(client,ability,bool:pressed)
 }
 public OnUltimateCommand(client,race,bool:pressed)
 {
-    
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(race==thisRaceID && pressed && ValidPlayer(client,true) &&!Silenced(client) )
     {
         new ult_level=War3_GetSkillLevel(client,race,ULT_BREAK);
@@ -284,5 +344,10 @@ public OnUltimateCommand(client,race,bool:pressed)
 }
 public bool:ConeTargetFilter(client)
 {
+    if(RaceDisabled)
+    {
+        return false;
+    }
+
     return (!W3HasImmunity(client,Immunity_Ultimates));
 }

--- a/addons/sourcemod/scripting/War3Source_017_Hammerstorm.sp
+++ b/addons/sourcemod/scripting/War3Source_017_Hammerstorm.sp
@@ -11,6 +11,23 @@ public Plugin:myinfo =
 };
 
 new thisRaceID;
+
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new SKILL_BOLT, SKILL_CLEAVE, SKILL_WARCRY, ULT_STRENGTH;
 
 // Tempents
@@ -83,11 +100,21 @@ public OnMapStart()
 
 public OnWar3EventSpawn(client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     bStrengthActivated[client] = false;
     W3ResetPlayerColor(client, thisRaceID);
 }
 
 public OnW3TakeDmgBulletPre(victim,attacker,Float:damage){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(victim,true)&&ValidPlayer(attacker,false)&&GetClientTeam(victim)!=GetClientTeam(attacker))
     {
         if(War3_GetRace(attacker)==thisRaceID)
@@ -105,6 +132,11 @@ public OnW3TakeDmgBulletPre(victim,attacker,Float:damage){
 }
             
 public OnW3TakeDmgBullet(victim,attacker,Float:damage){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(victim,true)&&ValidPlayer(attacker,false)&&GetClientTeam(victim)!=GetClientTeam(attacker))
     {
         if(War3_GetRace(attacker)==thisRaceID)
@@ -144,6 +176,11 @@ public OnW3TakeDmgBullet(victim,attacker,Float:damage){
 
 public OnAbilityCommand(client,ability,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(War3_GetRace(client)==thisRaceID && ability==0 && pressed && IsPlayerAlive(client))
     {
         new skilllvl = War3_GetSkillLevel(client,thisRaceID,SKILL_BOLT);
@@ -199,12 +236,22 @@ public OnAbilityCommand(client,ability,bool:pressed)
 
 public Action:UnstunPlayer(Handle:timer,any:client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     War3_SetBuff(client,bStunned,thisRaceID,false);
     W3ResetPlayerColor(client, thisRaceID);
 }
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(race==thisRaceID && pressed && ValidPlayer(client,true))
     {
         new skilllvl = War3_GetSkillLevel(client,thisRaceID,ULT_STRENGTH);
@@ -227,6 +274,11 @@ public OnUltimateCommand(client,race,bool:pressed)
 
 
 public Action:stopUltimate(Handle:t,any:client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     bStrengthActivated[client] = false;
     if(ValidPlayer(client,true)){
         PrintHintText(client,"%T","You feel less powerful",client);

--- a/addons/sourcemod/scripting/War3Source_018_Scout.sp
+++ b/addons/sourcemod/scripting/War3Source_018_Scout.sp
@@ -12,6 +12,21 @@ public Plugin:myinfo =
 };
 
 new thisRaceID;
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
 
 
 new SKILL_INVIS, SKILL_TRUESIGHT, SKILL_DISARM, ULT_MARKSMAN;
@@ -77,6 +92,11 @@ public OnWar3LoadRaceOrItemOrdered(num)
 
 public OnRaceChanged(client,oldrace,newrace)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(newrace==thisRaceID)
     {
         new level=War3_GetSkillLevel(client,thisRaceID,SKILL_TRUESIGHT);
@@ -91,6 +111,11 @@ public OnRaceChanged(client,oldrace,newrace)
 
 public OnSkillLevelChanged(client,race,skill,newskilllevel)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     
     if(race==thisRaceID && War3_GetRace(client)==thisRaceID)
     {
@@ -105,6 +130,11 @@ public OnSkillLevelChanged(client,race,skill,newskilllevel)
 }
 
 public OnWar3EventSpawn(client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(bDisarmed[client]){
         EndInvis2(INVALID_HANDLE,client);
     }
@@ -116,6 +146,11 @@ public OnWar3EventSpawn(client){
 }
 public OnAbilityCommand(client,ability,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(War3_GetRace(client)==thisRaceID &&  pressed && IsPlayerAlive(client))
     {
         new skilllvl = War3_GetSkillLevel(client,thisRaceID,SKILL_INVIS);
@@ -146,6 +181,11 @@ public OnAbilityCommand(client,ability,bool:pressed)
 }
 public Action:EndInvis(Handle:timer,any:client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     InInvis[client]=false;
     War3_SetBuff(client,fInvisibilitySkill,thisRaceID,1.0);
     War3_SetBuff(client,fHPDecay,thisRaceID,0.0);
@@ -154,12 +194,22 @@ public Action:EndInvis(Handle:timer,any:client)
     
 }
 public Action:EndInvis2(Handle:timer,any:client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     War3_SetBuff(client,bDisarm,thisRaceID,false);
     bDisarmed[client]=false;
 }
 
 public OnW3TakeDmgBulletPre(victim,attacker,Float:damage)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(victim)&&ValidPlayer(attacker))
     {
         new vteam=GetClientTeam(victim);
@@ -191,6 +241,11 @@ public OnW3TakeDmgBulletPre(victim,attacker,Float:damage)
 
 public OnWar3EventPostHurt(victim, attacker, Float:damage, const String:weapon[32], bool:isWarcraft)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(!isWarcraft && ValidPlayer(victim,true)&&ValidPlayer(attacker,true)&&GetClientTeam(victim)!=GetClientTeam(attacker))
     {    
         if(War3_GetRace(attacker)==thisRaceID)
@@ -210,11 +265,21 @@ public OnWar3EventPostHurt(victim, attacker, Float:damage, const String:weapon[3
     }           
 }
 public Action:Undisarm(Handle:t,any:client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     War3_SetBuff(client,bDisarm,thisRaceID,false);
 }
 
 
 public Action:DeciSecondTimer(Handle:t){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     for(new client=1;client<=MaxClients;client++){\
         if(ValidPlayer(client,true)&&War3_GetRace(client)==thisRaceID){
             static Float:vec[3];
@@ -234,6 +299,11 @@ public Action:DeciSecondTimer(Handle:t){
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(race==thisRaceID && IsPlayerAlive(client) && pressed)
     {
         new skill_level=War3_GetSkillLevel(client,race,SKILL_TRUESIGHT);
@@ -251,6 +321,11 @@ public OnUltimateCommand(client,race,bool:pressed)
     }
 }
 public OnW3PlayerAuraStateChanged(client,tAuraID,bool:inAura,level){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(tAuraID==thisAuraID){
         //DP(inAura?"In Aura":"Not in Aura");
         War3_SetBuff(client,bInvisibilityDenyAll,thisRaceID,inAura);

--- a/addons/sourcemod/scripting/War3Source_019_DarkElf.sp
+++ b/addons/sourcemod/scripting/War3Source_019_DarkElf.sp
@@ -11,6 +11,22 @@ public Plugin:myinfo =
 };
 
 new thisRaceID;
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 
 new SKILL_FADE,SKILL_SLOWFALL,SKILL_TRIBUNAL,ULTIMATE_DARKORB;
 
@@ -73,6 +89,11 @@ public OnMapStart()
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new userid=GetClientUserId(client);
     if(race==thisRaceID && pressed && userid>1 && IsPlayerAlive(client) )
     {
@@ -105,11 +126,21 @@ public OnUltimateCommand(client,race,bool:pressed)
 
 public bool:DarkorbFilter(client)
 {
+    if(RaceDisabled)
+    {
+        return false;
+    }
+
     return (!W3HasImmunity(client,Immunity_Ultimates));
 }
 
 public OnW3TakeDmgBulletPre(victim,attacker,Float:damage)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(IS_PLAYER(victim)&&IS_PLAYER(attacker)&&victim>0&&attacker>0&&attacker!=victim)
     {
         new vteam=GetClientTeam(victim);
@@ -136,6 +167,11 @@ public OnW3TakeDmgBulletPre(victim,attacker,Float:damage)
 
 public Action:FadeTimer(Handle:timer,any:victim)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
 
     War3_SetBuff(victim,fInvisibilitySkill,thisRaceID,1.0);
     
@@ -143,11 +179,21 @@ public Action:FadeTimer(Handle:timer,any:victim)
 
 public OnWar3EventSpawn(client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     StopTribunal(client);
 }
 
 public OnAbilityCommand(client,ability,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(War3_GetRace(client)==thisRaceID && ability==0 && pressed && ValidPlayer(client,true))
     {
         new skilllvl = War3_GetSkillLevel(client,thisRaceID,SKILL_TRIBUNAL);
@@ -186,6 +232,11 @@ public Action:TribunalTimer(Handle:timer,any:client)
 
 public Action:SlowfallTimer(Handle:timer,any:zclient)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     for(new client=1; client <= MaxClients; client++)
     {
         if(ValidPlayer(client, true))
@@ -201,6 +252,11 @@ public Action:SlowfallTimer(Handle:timer,any:zclient)
 }
 public Action:Slowfall2Timer(Handle:timer,any:client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(client, true)){
         GetClientAbsOrigin(client,darkvec);
         new flags = GetEntityFlags(client);
@@ -230,6 +286,11 @@ public Action:Slowfall2Timer(Handle:timer,any:client)
 
 public OnRaceChanged(client,oldrace,newrace)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(oldrace==thisRaceID)
     {
         War3_SetBuff(client,fLowGravitySkill,thisRaceID,1.0);
@@ -245,6 +306,11 @@ public OnRaceChanged(client,oldrace,newrace)
 
 StopTribunal(client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     IsInTribunal[client]=false;
     War3_SetBuff(client,fMaxSpeed,thisRaceID,1.0);
     War3_SetBuff(client,fHPDecay,thisRaceID,0.0);

--- a/addons/sourcemod/scripting/War3Source_020_Dragonborn.sp
+++ b/addons/sourcemod/scripting/War3Source_020_Dragonborn.sp
@@ -14,6 +14,23 @@ public Plugin:myinfo =
 
 new thisRaceID;
 
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
+
 public LoadCheck(){
     return GameTF();
 }
@@ -100,6 +117,11 @@ public OnMapStart()
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new userid=GetClientUserId(client);
     if(race==thisRaceID && pressed && userid>1 && IsPlayerAlive(client) )
     {
@@ -132,11 +154,21 @@ public OnUltimateCommand(client,race,bool:pressed)
 
 public bool:DragonFilter(client)
 {
+    if(RaceDisabled)
+    {
+        return false;
+    }
+
     return (!W3HasImmunity(client,Immunity_Ultimates));
 }
 
 public Action:HalfSecondTimer(Handle:timer,any:clientz) //footsy flame/water effects only on ground yay!
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     for(new client=1; client <= MaxClients; client++)
     {
         if(ValidPlayer(client, true))
@@ -152,13 +184,18 @@ public Action:HalfSecondTimer(Handle:timer,any:clientz) //footsy flame/water eff
     }
 }
 
-public Action:stopspeed(Handle:t,any:client){
+//public Action:stopspeed(Handle:t,any:client){
 //W3ResetBuffRace(client,fMaxSpeed,thisRaceID);
 //TF2_StunPlayer(client,0.0, 0.0,TF_STUNFLAGS_LOSERSTATE,0);
-}
+//}
 //Roar - If it's too overpowered I might add in an adrenaline effect to all clients effect afterward (Increased speed during thirdperson stun animation)
 public OnAbilityCommand(client,ability,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     //TF2_StunPlayer(client,5.0, 0.0,TF_STUNFLAG_SLOWDOWN|TF_STUNFLAG_THIRDPERSON,0);
     //War3_SetBuff(client,fMaxSpeed,thisRaceID,2.0);
     //CreateTimer(1.0,stopspeed,client);
@@ -210,6 +247,11 @@ public OnAbilityCommand(client,ability,bool:pressed)
 
 public InitPassiveSkills(client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(War3_GetRace(client)==thisRaceID)
     {
         //dragonborn
@@ -237,6 +279,11 @@ public InitPassiveSkills(client)
     }
 }
 RemoveImmunity(client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     War3_SetBuff(client,bImmunityWards,thisRaceID,0);
     War3_SetBuff(client,bImmunitySkills,thisRaceID,0);
     War3_SetBuff(client,bSlowImmunity,thisRaceID,0);
@@ -244,6 +291,11 @@ RemoveImmunity(client){
 }
 public OnRaceChanged(client,oldrace,newrace)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(newrace==thisRaceID)
     {    
         InitPassiveSkills(client);

--- a/addons/sourcemod/scripting/War3Source_021_Fluttershy.sp
+++ b/addons/sourcemod/scripting/War3Source_021_Fluttershy.sp
@@ -14,6 +14,22 @@ public Plugin:myinfo =
 
 new thisRaceID;
 
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 public LoadCheck(){
     return GameTF();
 }
@@ -53,6 +69,11 @@ public OnPluginStart()
 
 public OnUltimateCommand(client,race,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(race==thisRaceID && pressed && ValidPlayer(client,true) )
     {
         new ult_level=War3_GetSkillLevel(client,race,ULTIMATE_YOUBEGENTLE);
@@ -80,9 +101,19 @@ public OnUltimateCommand(client,race,bool:pressed)
     }            
 }
 public Action:EndNotBad(Handle:t,any:client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     bNoDamage[client]=false;
 }
 public OnW3TakeDmgBulletPre(victim,attacker,Float:damage){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(attacker)&&bNoDamage[attacker]){
         War3_DamageModPercent(0.0);
     }
@@ -92,6 +123,11 @@ new StareVictim[MAXPLAYERSCUSTOM];
 
 public OnAbilityCommand(client,ability,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(client,true) && War3_GetRace(client)==thisRaceID && ability==0 && pressed )
     {
         if(!Silenced(client)&&War3_SkillNotInCooldown(client,thisRaceID,SKILL_STARE,true))
@@ -122,6 +158,11 @@ public OnAbilityCommand(client,ability,bool:pressed)
     }
 }
 public Action:EndStare(Handle:t,any:client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     War3_SetBuff(client,bBashed,thisRaceID,false);
     War3_SetBuff(client,bDisarm,thisRaceID,false);
     War3_SetBuff(StareVictim[client],bBashed,thisRaceID,false);
@@ -130,6 +171,11 @@ public Action:EndStare(Handle:t,any:client){
 }
 
 public OnWar3EventDeath(client){ //end stare if fluttershy dies
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(client))
     {
         War3_SetBuff(client,bBashed,thisRaceID,false);
@@ -147,7 +193,12 @@ public OnWar3EventDeath(client){ //end stare if fluttershy dies
 
 
 public OnSkillLevelChanged(client,race,skill,newskilllevel)
-{    
+{
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(race==thisRaceID &&skill==SKILL_TOLERATE)    {
         War3_SetBuff(client,fArmorPhysical,thisRaceID,ArmorPhysical[newskilllevel]);
     }
@@ -163,6 +214,11 @@ public OnSkillLevelChanged(client,race,skill,newskilllevel)
 
 public OnW3PlayerAuraStateChanged(client,aura,bool:inAura,level)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(aura==AuraID&&inAura==false) //lost aura, remove helaing
     {
         War3_SetBuff(client,fHPRegen,thisRaceID,0.0);
@@ -170,12 +226,22 @@ public OnW3PlayerAuraStateChanged(client,aura,bool:inAura,level)
     }
 }
 public OnWar3Event(W3EVENT:event,client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(event==OnAuraCalculationFinished){
         RecalculateHealing();
     //    DP("re");
     }
 }
 RecalculateHealing(){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     new level;
     new playerlist[66];
     new auralevel[66];

--- a/addons/sourcemod/scripting/War3Source_022_Rarity.sp
+++ b/addons/sourcemod/scripting/War3Source_022_Rarity.sp
@@ -13,6 +13,23 @@ public Plugin:myinfo =
 
 new thisRaceID;
 
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
+
 new SKILL_SMITTEN,SKILL_HEARTACHE,SKILL_SLEEP,ULTIMATE;
 ///based on succubus HON
 
@@ -63,6 +80,11 @@ public OnMapStart()
 
 }
 public OnWar3EventSpawn(client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     bSmittened[client]=false;
 }
 
@@ -70,6 +92,11 @@ public OnWar3EventSpawn(client){
 
 public OnW3TakeDmgBulletPre(victim,attacker,Float:damage)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(victim)&&ValidPlayer(attacker)&&attacker!=victim )
     {
         if(GetClientTeam(victim)!=GetClientTeam(attacker))
@@ -99,6 +126,11 @@ public OnW3TakeDmgBulletPre(victim,attacker,Float:damage)
 
 public Action:UnSmitten(Handle:timer,any:client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     bSmittened[client]=false;
 }
 
@@ -109,6 +141,11 @@ public Action:UnSmitten(Handle:timer,any:client)
 
 public OnWar3EventPostHurt(victim, attacker, Float:damage, const String:weapon[32], bool:isWarcraft)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(!isWarcraft && War3_GetRace(attacker)==thisRaceID ){
         new lvl = War3_GetSkillLevel(attacker,thisRaceID,SKILL_HEARTACHE);
         if(lvl > 0  )
@@ -144,12 +181,22 @@ public OnWar3EventPostHurt(victim, attacker, Float:damage, const String:weapon[3
 
 public bool:AbilityFilter(client)
 {
+    if(RaceDisabled)
+    {
+        return false;
+    }
+
     return (!IsSkillImmune(client));
 }
 
 
 public OnAbilityCommand(client,ability,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(War3_GetRace(client)==thisRaceID && ability==0 && pressed && IsPlayerAlive(client))
     {
         new lvl = War3_GetSkillLevel(client,thisRaceID,SKILL_SLEEP);
@@ -185,6 +232,11 @@ public OnAbilityCommand(client,ability,bool:pressed)
     }
 }
 Sleep(client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     War3_SetBuff(client,bStunned,thisRaceID,true);
     PrintHintText(client,"%T","You are Mesmerized",client);
     if(GameTF()){
@@ -193,6 +245,10 @@ Sleep(client){
 }
 
 public Action:EndSleep(Handle:t,any:client){
+    if(RaceDisabled)
+    {
+        return;
+    }
 
     SleepTimer[client]=INVALID_HANDLE;
     CloseHandle(SleepHandle[client]);
@@ -201,6 +257,11 @@ public Action:EndSleep(Handle:t,any:client){
     UnSleep(client);
 }
 UnSleep(client){
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     War3_SetBuff(client,bStunned,thisRaceID,false);
     PrintHintText(client,"%T","No Longer Mesmerized",client);
 }

--- a/addons/sourcemod/scripting/War3Source_023_RainbowDash.sp
+++ b/addons/sourcemod/scripting/War3Source_023_RainbowDash.sp
@@ -14,6 +14,22 @@ public Plugin:myinfo =
 new HaloSprite, XBeamSprite;
 new thisRaceID;
 
+new bool:RaceDisabled=true;
+public OnWar3RaceEnabled(newrace)
+{
+    if(newrace==thisRaceID)
+    {
+        RaceDisabled=false;
+    }
+}
+public OnWar3RaceDisabled(oldrace)
+{
+    if(oldrace==thisRaceID)
+    {
+        RaceDisabled=true;
+    }
+}
+
 new Float:fEvadeChance[5]={0.0,0.05,0.09,0.12,0.15};
 new Float:fSwiftASPDBuff[5]={1.0,1.04,1.08,1.12,1.15};
 new Float:abilityspeed[5]={1.0,1.075,1.15,1.225,1.30};
@@ -50,6 +66,11 @@ public OnMapStart()
 
 public OnAbilityCommand(client,ability,bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(ValidPlayer(client, true) && pressed)
     {
         new skill_level = War3_GetSkillLevel(client, thisRaceID, SKILL_SPEED);
@@ -76,7 +97,11 @@ public OnAbilityCommand(client,ability,bool:pressed)
 }
 
 public Action:EndSpeed(Handle:t, any:client){
-    
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(GAMETF)
     {
         TF2_RemoveCondition(client, TFCond_SpeedBuffAlly);
@@ -91,6 +116,11 @@ public Action:EndSpeed(Handle:t, any:client){
 
 public OnWar3EventDeath(client)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(speedendtimer[client] != INVALID_HANDLE)
     {
         TriggerTimer(speedendtimer[client]);
@@ -99,6 +129,11 @@ public OnWar3EventDeath(client)
 
 public OnWar3EventPostHurt(victim, attacker, Float:damage, const String:weapon[32], bool:isWarcraft)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     LastDamageTime[victim] = GetEngineTime();
     if(speedendtimer[victim] != INVALID_HANDLE)
     {
@@ -113,6 +148,11 @@ public OnWar3EventPostHurt(victim, attacker, Float:damage, const String:weapon[3
 
 public OnUltimateCommand(client, race, bool:pressed)
 {
+    if(RaceDisabled)
+    {
+        return;
+    }
+
     if(race == thisRaceID && pressed && ValidPlayer(client, true))
     {
         new skill = War3_GetSkillLevel(client, race, ULTIMATE);


### PR DESCRIPTION
To disable this feature, War3Source owners can add war3_race_dynamic_loading 0 to their config files.

This feature "turns off" races that are not being used by players in game.   A performance increase can be felt by low end box servers.   Our Higher end box servers noticed less lag, so it got coined as "lag free technology".

We have been using this for over a year now with no fault.   It has been well tested.
