### PR TITLE
Fix a bug that allows levelbanking when denied

### DIFF
--- a/addons/sourcemod/scripting/War3Source_Engine_PlayerLevelbank.sp
+++ b/addons/sourcemod/scripting/War3Source_Engine_PlayerLevelbank.sp
@@ -86,7 +86,7 @@ public OnSelectShowLevelBankMenu(Handle:menu,MenuAction:action,client,selection)
 {
     if(action==MenuAction_Select)
     {
-        if(selection==0){
+        if(selection==0 && W3Denyable(DN_ShowLevelbank,client)){        
             SetTrans(client);
             if(W3GetLevelBank(client)<=0){
                 War3_ChatMessage(client,"%T","You do not have any levels in the level bank",client);


### PR DESCRIPTION
If you changed race, then opened levelbank menu, then changed via say command to the denied race, you could still put 1 levelbank into a race at a time.

This closes that loop, so that not only will it not display the levelbank menu on the denyable, but it won't give a levelbank at all.