### PR TITLE
Temporary bug fix

### DIFF
--- a/addons/sourcemod/scripting/War3Source_Engine_Config.sp
+++ b/addons/sourcemod/scripting/War3Source_Engine_Config.sp
@@ -81,7 +81,7 @@ public OnWar3PluginReady()
     War3_SetRaceGlobalConfigString("restricted_hugalug","None");
     War3_SetRaceGlobalConfigString("restricted_blah","Some");
     War3_SetRaceGlobalConfigString("restricted_blah23","Some");
-    ReloadConfig();
+    //ReloadConfig();
 }
 
 ReloadConfig()


### PR DESCRIPTION
Stopped the auto generation of malformed config file.

This is a temporary immediate fix until the problem is resolved properly.  I personally suggest removing this system completely, as it was never finished, is not used, and to my mind was always pretty limited anyway.