### PR TITLE
Update War3Source_Engine_MenuShopmenu.sp

### DIFF
--- a/addons/sourcemod/scripting/War3Source_Engine_MenuShopmenu.sp
+++ b/addons/sourcemod/scripting/War3Source_Engine_MenuShopmenu.sp
@@ -268,10 +268,18 @@ War3_TriedToBuyItem(client, item, bool:reshowmenu=true)
         }
         else if(currency < cost) 
         {
+            new bool:useCategory = GetConVarBool(hUseCategorysCvar);
             War3_ChatMessage(client, "%T", "You cannot afford {itemname}", GetTrans(), itemname);
             if(reshowmenu) 
             {
-                ShowMenuShop(client);
+                if (useCategory)
+                {
+                     ShowMenuShopCategory(client);
+                }
+                else
+                {
+                     ShowMenuShop(client);
+                }
             }
             bCanBuy = false;
         }


### PR DESCRIPTION
Fixes
* Forces Cvar check for ShopMenuCategories if player can not afford item.