### PR TITLE
Implement bHPRegenDeny and bHPDecayDeny. Fixes #205

### DIFF
--- a/addons/sourcemod/scripting/W3SIncs/War3Source_Constants.inc
+++ b/addons/sourcemod/scripting/W3SIncs/War3Source_Constants.inc
@@ -327,7 +327,7 @@ enum W3Buff
   
   fHPRegen, ///float sum! NO NEGATIVES! MINIM regin rate is 0.5 / second ( 1 hp per 2 seconds)
   fHPDecay, //float sum, NO NEGATIVES, postive means lose this much HP / second, same requirements as fHPRegen
-  fHPRegenDeny, //set true to deny hp regen
+  bHPRegenDeny, //set true to deny hp regen
   iAdditionalMaxHealth,   ///increase / decrease in maxhp
   
   //44
@@ -353,8 +353,9 @@ enum W3Buff
   fDamageModifier, //Gives a % increase to damage done
 
   iAdditionalMaxHealthNoHPChange,   ///increase / decrease in maxhp. NO AUTOMATIC HP CHANGE WHEN BUFF IS CHANGED
+  bHPDecayDeny, //set true to deny hp decay
   MaxBuffLoopLimitTemp, //this is a variable that is for loops, this number is automatically generated from the enum.
-  
+  fHPRegenDeny = bHPRegenDeny, //backwards compatibility macro for 'bHPRegenDeny'
 }
 stock MaxBuffLoopLimit=_:MaxBuffLoopLimitTemp;
 
@@ -507,8 +508,11 @@ stock InitiateBuffPropertiesArray(buffpropertiesarray[W3Buff][W3BuffProperties])
   buffpropertiesarray[ fHPDecay][DefaultValue]=0.0;
   buffpropertiesarray[ fHPDecay][BuffStackType]=fAbsolute;  
   
-  buffpropertiesarray[ fHPRegenDeny][DefaultValue]=false;
-  buffpropertiesarray[ fHPRegenDeny][BuffStackType]=bHasOneTrue;  
+  buffpropertiesarray[ bHPRegenDeny][DefaultValue]=false;
+  buffpropertiesarray[ bHPRegenDeny][BuffStackType]=bHasOneTrue;  
+  
+  buffpropertiesarray[ bHPDecayDeny][DefaultValue]=false;
+  buffpropertiesarray[ bHPDecayDeny][BuffStackType]=bHasOneTrue;  
   
   buffpropertiesarray[ iAdditionalMaxHealth ][DefaultValue]=0;
   buffpropertiesarray[ iAdditionalMaxHealth ][BuffStackType]=iAbsolute;

--- a/addons/sourcemod/scripting/War3Source_Engine_Regen.sp
+++ b/addons/sourcemod/scripting/War3Source_Engine_Regen.sp
@@ -28,12 +28,15 @@ public OnGameFrame()
         if(ValidPlayer(client,true))
         {
             new Float:fbuffsum = 0.0;
-            if(!W3GetBuffHasTrue(client, bBuffDenyAll))
+            if(!W3GetBuffHasTrue(client, bBuffDenyAll) && !W3GetBuffHasTrue(client, bHPRegenDeny))
             {
                 fbuffsum += W3GetBuffSumFloat(client, fHPRegen);
             }
 
-            fbuffsum -= W3GetBuffSumFloat(client, fHPDecay);
+            if(!W3GetBuffHasTrue(client, bHPDecayDeny))
+            {
+                fbuffsum -= W3GetBuffSumFloat(client, fHPDecay);
+            }
 
             if(fbuffsum < 0.01 && fbuffsum > -0.01)
             {


### PR DESCRIPTION
This implements defunct bHPRegenDeny(former fHPRegenDeny) and adds bHPDecayDeny to ignore fHPDecay buffs(especially usefull for races like Wisp, as mentioned in #205).